### PR TITLE
Create error type

### DIFF
--- a/automaton/Cargo.toml
+++ b/automaton/Cargo.toml
@@ -22,3 +22,5 @@ publish = false
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.59"
+thiserror = "1.0.31"

--- a/automaton/src/error.rs
+++ b/automaton/src/error.rs
@@ -1,0 +1,35 @@
+use thiserror::Error;
+
+/// Errors that an automaton can return
+///
+/// When an automaton executes its tasks, things can fail. Automatons might interact with external
+/// resources or third-party APIs that are unreliable, the configuration might be wrong, or
+/// something totally unexpected might happen. In these situations, automatons can abort their
+/// execution and return an [`Error`].
+///
+/// # Example
+///
+/// The implementation of the error type is based on [thiserror] and [anyhow]. Unexpected errors can
+/// easily be converted to an error by calling `.context` on the original error.
+///
+/// ```rust
+/// use std::io::ErrorKind;
+///
+/// use anyhow::Context;
+/// use automaton::Error;
+///
+/// fn connect() -> Result<(), Error> {
+///     let failure = Err(std::io::Error::new(ErrorKind::TimedOut, "connection timed out"));
+///     let error = failure.context("failed to connect to API due to connection time out")?;
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// anyhow: https://crates.io/crates/anyhow
+/// thiserror: https://crates.io/crates/thiserror
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Unknown(#[from] anyhow::Error),
+}

--- a/automaton/src/lib.rs
+++ b/automaton/src/lib.rs
@@ -1,3 +1,5 @@
+pub use crate::error::Error;
 pub use crate::state::State;
 
+mod error;
 mod state;


### PR DESCRIPTION
A custom error type for automatons has been created. These errors cannot be recovered by the automaton itself, and have to be handled by the runtime. The error type is implemented using the crates `thiserror` [^1] and `anyhow` [^2].

[^1]: https://crates.io/crates/thiserror
[^2]: https://crates.io/crates/anyhow