### PR TITLE
Add support for tracing

### DIFF
--- a/automaton/Cargo.toml
+++ b/automaton/Cargo.toml
@@ -25,6 +25,7 @@ publish = false
 anyhow = "1.0.59"
 async-trait = "0.1.57"
 thiserror = "1.0.31"
+tracing = { version = "0.1.36", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["full"] }

--- a/automaton/tests/hello-world.rs
+++ b/automaton/tests/hello-world.rs
@@ -14,8 +14,10 @@ async fn test() -> Result<(), Error> {
 }
 
 // Return type
+#[derive(Debug)]
 struct Message(String);
 // Automaton
+#[derive(Debug)]
 struct HelloWorld;
 // Task
 struct Hello;


### PR DESCRIPTION
Users of the library can now enable the `tracing` feature, which adds instrumentation to the functions inside the library. The feature is optional to avoid pulling in more dependencies than necessary.