### PR TITLE
Create empty crate for GitHub integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "automaton",
+    "automaton-github",
 ]

--- a/automaton-github/Cargo.toml
+++ b/automaton-github/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "automaton-github"
+version = "0.0.0"
+edition = "2021"
+
+repository = "https://github.com/devxbots/automatons"
+license = "MIT or Apache-2.0"
+
+categories = [
+    "development-tools"
+]
+keywords = [
+    "github",
+    "github-app",
+]
+
+# automaton-github is currently in a prototyping phase, during which we won't
+# release it to crates.io yet.
+publish = false
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/automaton-github/src/lib.rs
+++ b/automaton-github/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
A new crate has been generated for the integration with GitHub. The
crate will contain two resources: data types and tasks. The data types
represent resources on GitHub, and the tasks allow users to interact
with them. The implementation will be inspired by GitHub's REST API
[^1], provide higher-level interfaces as well.

[^1]: https://docs.github.com/en/rest