### PR TITLE
Enable documentation of identifier types

### DIFF
--- a/automaton-github/src/macros.rs
+++ b/automaton-github/src/macros.rs
@@ -14,7 +14,11 @@
 /// ```
 #[macro_export]
 macro_rules! id {
-    ($id:ident) => {
+    (
+        $(#[$meta:meta])*
+        $id:ident
+    ) => {
+        $(#[$meta])*
         #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         pub struct $id(u64);
@@ -67,7 +71,11 @@ macro_rules! id {
 /// ```
 #[macro_export]
 macro_rules! name {
-    ($name:ident) => {
+    (
+        $(#[$meta:meta])*
+        $name:ident
+    ) => {
+        $(#[$meta])*
         #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         pub struct $name(String);
@@ -112,7 +120,10 @@ macro_rules! name {
 mod tests {
     use crate::{id, name};
 
-    id!(TestId);
+    id!(
+        /// Identifier for tests
+        TestId
+    );
 
     #[test]
     fn id() {
@@ -127,7 +138,10 @@ mod tests {
         let _id: TestId = 42.into();
     }
 
-    name!(TestName);
+    name!(
+        /// Name for tests
+        TestName
+    );
 
     #[test]
     fn name() {


### PR DESCRIPTION
The macro rules that generate identifier types for GitHub have been extended to allow developers to document the generated types. While designed for documentation, the implementation actually allows arbitrary attributes to be added to identifiers.