### PR TITLE
Prepare release to crates.io

### DIFF
--- a/.github/workflows/release-automatons-github.yml
+++ b/.github/workflows/release-automatons-github.yml
@@ -1,0 +1,28 @@
+---
+name: Release automatons-github
+
+"on":
+  push:
+    tags:
+      - automatons-github@*
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache build artifacts
+        uses: swatinem/rust-cache@v2.0.0
+
+      - name: Publish to crates.io
+        run: cargo publish -v -p automatons-github --all-features --token ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release-automatons.yml
+++ b/.github/workflows/release-automatons.yml
@@ -1,0 +1,28 @@
+---
+name: Release automatons
+
+"on":
+  push:
+    tags:
+      - automatons@*
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache build artifacts
+        uses: swatinem/rust-cache@v2.0.0
+
+      - name: Publish to crates.io
+        run: cargo publish -v -p automatons --all-features --token ${{ secrets.CRATES_TOKEN }}

--- a/automatons-github/Cargo.toml
+++ b/automatons-github/Cargo.toml
@@ -14,10 +14,6 @@ keywords = [
     "github-app",
 ]
 
-# automaton-github is currently in a prototyping phase, during which we won't
-# release it to crates.io yet.
-publish = false
-
 [features]
 serde = ["dep:serde", "dep:serde_json", "url/serde"]
 

--- a/automatons/Cargo.toml
+++ b/automatons/Cargo.toml
@@ -14,10 +14,6 @@ keywords = [
     "github-app",
 ]
 
-# automaton is currently in a prototyping phase, during which we won't release
-# it to crates.io yet.
-publish = false
-
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Two workflows have been created to publish the two crates to crates.io. Each has its own tag that triggers the automation.