### PR TITLE
Fix license expression

### DIFF
--- a/automatons-github/Cargo.toml
+++ b/automatons-github/Cargo.toml
@@ -3,8 +3,9 @@ name = "automatons-github"
 version = "0.0.0"
 edition = "2021"
 
+description = "GitHub integration for the automatons framework"
 repository = "https://github.com/devxbots/automatons"
-license = "MIT or Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 categories = [
     "development-tools"

--- a/automatons/Cargo.toml
+++ b/automatons/Cargo.toml
@@ -3,8 +3,9 @@ name = "automatons"
 version = "0.1.0"
 edition = "2021"
 
+description = "Automation framework for software developers"
 repository = "https://github.com/devxbots/automatons"
-license = "MIT or Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 categories = [
     "development-tools"


### PR DESCRIPTION
The license expressions in the Cargo manifests did not match the expected syntax. Furthermore, a description is required to publish to crates.io.