### PR TITLE
Enable dependabot for Cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,16 @@ updates:
       - C-dependency
       - L-github
       - R-ignore
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-rust
+      - R-ignore


### PR DESCRIPTION
The configuration for dependabot has been extended to cover the Rust ecosystem as well. This ensures that we get notified of new versions and manage to stay up-to-date.