### PR TITLE
Create resource for apps

### DIFF
--- a/automatons-github/src/resource/app.rs
+++ b/automatons-github/src/resource/app.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+use chrono::{DateTime, Utc};
+use url::Url;
+
+use crate::resource::{Account, NodeId};
+use crate::{id, name};
+
+id!(
+    /// App id
+    ///
+    /// The [`AppId`] is a unique, numerical id that is used to interact with an app through
+    /// [GitHub's REST API](https://docs.github.com/en/rest).
+    AppId
+);
+
+name!(
+    /// App name
+    ///
+    /// Apps on GitHub have a human-readable name that is used throughout GitHub's website as well
+    /// as for status checks.
+    AppName
+);
+
+name!(
+    /// App slug
+    ///
+    /// The [`AppSlug`] is a URL-friendly version of the app's name.
+    AppSlug
+);
+
+/// GitHub App
+///
+/// Third-parties can create integrations with the GitHub platform by creating a GitHub App. Apps
+/// have their own identify and authentication, and can request granular permissions and access to
+/// events. Every [`App`] is owned by an [`Account`].
+#[derive(Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct App {
+    id: AppId,
+    node_id: NodeId,
+    name: AppName,
+    slug: AppSlug,
+    owner: Account,
+    description: String,
+    external_url: Url,
+    html_url: Url,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    permissions: HashMap<String, String>,
+    events: Vec<String>,
+}
+
+impl App {
+    /// Returns the app's id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn id(&self) -> AppId {
+        self.id
+    }
+
+    /// Returns the app's node id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    /// Returns the app's name.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn name(&self) -> &AppName {
+        &self.name
+    }
+
+    /// Returns the app's slug.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn slug(&self) -> &AppSlug {
+        &self.slug
+    }
+
+    /// Returns the app's owner.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn owner(&self) -> &Account {
+        &self.owner
+    }
+
+    /// Returns the app's description.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn description(&self) -> &String {
+        &self.description
+    }
+
+    /// Returns the URL to the app's external website.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn external_url(&self) -> &Url {
+        &self.external_url
+    }
+
+    /// Returns the URL to the app's website on GitHub.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn html_url(&self) -> &Url {
+        &self.html_url
+    }
+
+    /// Returns the date when the app was created.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn created_at(&self) -> &DateTime<Utc> {
+        &self.created_at
+    }
+
+    /// Returns the date when the app was last updated.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn updated_at(&self) -> &DateTime<Utc> {
+        &self.updated_at
+    }
+
+    /// Returns the app's permissions.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn permissions(&self) -> &HashMap<String, String> {
+        &self.permissions
+    }
+
+    /// Returns the events to which the app is subscribed.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn events(&self) -> &Vec<String> {
+        &self.events
+    }
+}
+
+impl Display for App {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::App;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let app: App =
+            serde_json::from_str(include_str!("../../tests/fixtures/resource/app.json")).unwrap();
+
+        assert_eq!("devxbots/checkbot", app.name().get());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_display() {
+        let app: App =
+            serde_json::from_str(include_str!("../../tests/fixtures/resource/app.json")).unwrap();
+
+        assert_eq!("devxbots/checkbot", app.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<App>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<App>();
+    }
+}

--- a/automatons-github/src/resource/mod.rs
+++ b/automatons-github/src/resource/mod.rs
@@ -9,11 +9,13 @@
 use crate::name;
 
 pub use self::account::{Account, AccountId, AccountType, Login};
+pub use self::app::{App, AppId, AppName, AppSlug};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
 pub use self::repository::{Repository, RepositoryFullName, RepositoryId, RepositoryName};
 pub use self::visibility::Visibility;
 
 mod account;
+mod app;
 mod license;
 mod repository;
 mod visibility;

--- a/automatons-github/tests/fixtures/resource/app.json
+++ b/automatons-github/tests/fixtures/resource/app.json
@@ -1,0 +1,37 @@
+{
+  "id": 202198,
+  "slug": "devxbots-checkbot",
+  "node_id": "A_kwHOBjmsBc4AAxXW",
+  "owner": {
+    "login": "devxbots",
+    "id": 104442885,
+    "node_id": "O_kgDOBjmsBQ",
+    "avatar_url": "https://avatars.githubusercontent.com/u/104442885?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/devxbots",
+    "html_url": "https://github.com/devxbots",
+    "followers_url": "https://api.github.com/users/devxbots/followers",
+    "following_url": "https://api.github.com/users/devxbots/following{/other_user}",
+    "gists_url": "https://api.github.com/users/devxbots/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/devxbots/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/devxbots/subscriptions",
+    "organizations_url": "https://api.github.com/users/devxbots/orgs",
+    "repos_url": "https://api.github.com/users/devxbots/repos",
+    "events_url": "https://api.github.com/users/devxbots/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/devxbots/received_events",
+    "type": "Organization",
+    "site_admin": false
+  },
+  "name": "devxbots/checkbot",
+  "description": "checkbot is a GitHub App that combines [required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks) with [filters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters) for GitHub Actions. It makes it possible to skip workflows based on a filter, and still require jobs in the workflow to succeed if they run.",
+  "external_url": "https://devxbots.com",
+  "html_url": "https://github.com/apps/devxbots-checkbot",
+  "created_at": "2022-05-18T19:21:10Z",
+  "updated_at": "2022-07-20T10:28:56Z",
+  "permissions": {
+    "checks": "write",
+    "metadata": "read",
+    "single_file": "read"
+  },
+  "events": ["check_run"]
+}


### PR DESCRIPTION
Third-parties can integrate with the GitHub platform by creating a GitHub App, for which a new resource has been added. Apps have a unique name, an owner, and some metadata.