### PR TITLE
Create minimal representation for repositories

### DIFF
--- a/automatons-github/src/resource/mod.rs
+++ b/automatons-github/src/resource/mod.rs
@@ -13,7 +13,9 @@ pub use self::app::{App, AppId, AppName, AppSlug};
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
 pub use self::organization::{Organization, OrganizationId};
-pub use self::repository::{Repository, RepositoryFullName, RepositoryId, RepositoryName};
+pub use self::repository::{
+    MinimalRepository, Repository, RepositoryFullName, RepositoryId, RepositoryName,
+};
 pub use self::visibility::Visibility;
 
 mod account;

--- a/automatons-github/src/resource/repository/minimal.rs
+++ b/automatons-github/src/resource/repository/minimal.rs
@@ -1,0 +1,109 @@
+use std::fmt::{Display, Formatter};
+
+use url::Url;
+
+use crate::resource::{RepositoryId, RepositoryName};
+
+/// Minimal representation of a [`Repository`]
+///
+/// GitHub truncates data types in some API responses and webhook events to reduce the payload size.
+/// The [`MinimalRepository`] represents a `[Repository`], but contains only the most basic fields.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct MinimalRepository {
+    id: RepositoryId,
+    name: RepositoryName,
+    url: Url,
+}
+
+impl MinimalRepository {
+    /// Returns the repository's id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn id(&self) -> RepositoryId {
+        self.id
+    }
+
+    /// Returns the repository's name.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn name(&self) -> &RepositoryName {
+        &self.name
+    }
+
+    /// Returns the API endpoint to query the repository.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+}
+
+impl Display for MinimalRepository {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = self
+            .url
+            .path_segments()
+            .and_then(|segments| {
+                let user_and_repo: Vec<&str> = segments.rev().take(2).collect();
+
+                if user_and_repo.len() != 2 {
+                    return None;
+                }
+
+                Some(
+                    user_and_repo
+                        .into_iter()
+                        .rev()
+                        .collect::<Vec<&str>>()
+                        .join("/"),
+                )
+            })
+            .unwrap_or_else(|| self.name.to_string());
+
+        write!(f, "{}", name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::{MinimalRepository, RepositoryId, RepositoryName};
+
+    const JSON: &str = r#"
+    {
+        "id": 518377950,
+        "url": "https://api.github.com/repos/devxbots/automatons",
+        "name": "automatons"
+    }
+    "#;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let repository: MinimalRepository = serde_json::from_str(JSON).unwrap();
+
+        assert_eq!("automatons", repository.name().get());
+    }
+
+    #[test]
+    fn trait_display() {
+        let repository = MinimalRepository {
+            id: RepositoryId::new(518377950),
+            name: RepositoryName::new("automatons"),
+            url: Url::parse("https://api.github.com/repos/devxbots/automatons").unwrap(),
+        };
+
+        assert_eq!("devxbots/automatons", repository.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<MinimalRepository>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<MinimalRepository>();
+    }
+}

--- a/automatons-github/src/resource/repository/mod.rs
+++ b/automatons-github/src/resource/repository/mod.rs
@@ -1,9 +1,14 @@
-use chrono::{DateTime, Utc};
 use std::fmt::{Display, Formatter};
+
+use chrono::{DateTime, Utc};
 use url::Url;
 
 use crate::resource::{Account, License, NodeId, Visibility};
 use crate::{id, name};
+
+pub use self::minimal::MinimalRepository;
+
+mod minimal;
 
 id!(
     /// Repository id
@@ -35,9 +40,10 @@ name!(
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Repository {
-    id: RepositoryId,
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    minimal: MinimalRepository,
+
     node_id: NodeId,
-    name: RepositoryName,
     owner: Account,
     full_name: RepositoryFullName,
     description: String,
@@ -64,7 +70,6 @@ pub struct Repository {
     is_template: bool,
     web_commit_signoff_required: bool,
     html_url: Url,
-    url: Url,
     keys_url: Url,
     collaborators_url: Url,
     teams_url: Url,
@@ -114,7 +119,7 @@ impl Repository {
     /// Returns the repository's unique id.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn id(&self) -> RepositoryId {
-        self.id
+        self.minimal.id()
     }
 
     /// Returns the repository's node id.
@@ -126,7 +131,7 @@ impl Repository {
     /// Returns the repository's name.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn name(&self) -> &RepositoryName {
-        &self.name
+        self.minimal.name()
     }
 
     /// Returns the account which ows the repository.
@@ -288,7 +293,7 @@ impl Repository {
     /// Returns the API endpoint to query the repository.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn url(&self) -> &Url {
-        &self.url
+        self.minimal.url()
     }
 
     /// Returns the API endpoint to query the repository's keys.
@@ -564,7 +569,7 @@ mod tests {
     #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let repository: Repository = serde_json::from_str(include_str!(
-            "../../tests/fixtures/resource/repository.json"
+            "../../../tests/fixtures/resource/repository.json"
         ))
         .unwrap();
 
@@ -575,7 +580,7 @@ mod tests {
     #[cfg(feature = "serde")]
     fn trait_display() {
         let repository: Repository = serde_json::from_str(include_str!(
-            "../../tests/fixtures/resource/repository.json"
+            "../../../tests/fixtures/resource/repository.json"
         ))
         .unwrap();
 


### PR DESCRIPTION
GitHub truncates data types in some API responses and webhook events to reduce the payload size. A minimal representation of a repository has been added for such situations.