### PR TITLE
Create resource for pull requests

### DIFF
--- a/automatons-github/src/resource/mod.rs
+++ b/automatons-github/src/resource/mod.rs
@@ -13,6 +13,7 @@ pub use self::app::{App, AppId, AppName, AppSlug};
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
 pub use self::organization::{Organization, OrganizationId};
+pub use self::pull_request::{PullRequest, PullRequestBranch, PullRequestId, PullRequestNumber};
 pub use self::repository::{
     MinimalRepository, Repository, RepositoryFullName, RepositoryId, RepositoryName,
 };
@@ -23,6 +24,7 @@ mod app;
 mod installation;
 mod license;
 mod organization;
+mod pull_request;
 mod repository;
 mod visibility;
 

--- a/automatons-github/src/resource/pull_request/branch.rs
+++ b/automatons-github/src/resource/pull_request/branch.rs
@@ -1,0 +1,90 @@
+use std::fmt::{Display, Formatter};
+
+use crate::resource::MinimalRepository;
+
+/// Pull request branch reference
+///
+/// Pull requests have a `base` branch against which they are opened, and a `head` branch that
+/// contains the changes that should be merged. The [`PullRequest`] resource references these using
+/// the [`PullRequestBranch`] data type.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PullRequestBranch {
+    #[cfg_attr(feature = "serde", serde(rename = "ref"))]
+    git_ref: String,
+
+    #[cfg_attr(feature = "serde", serde(rename = "sha"))]
+    git_sha: String,
+
+    repo: MinimalRepository,
+}
+
+impl PullRequestBranch {
+    /// Returns the pull request branch's git ref.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn git_ref(&self) -> &str {
+        &self.git_ref
+    }
+
+    /// Returns the pull request branch's git sha.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn git_sha(&self) -> &str {
+        &self.git_sha
+    }
+
+    /// Returns the repository in which the pull request was created.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn repository(&self) -> &MinimalRepository {
+        &self.repo
+    }
+}
+
+impl Display for PullRequestBranch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.git_ref)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PullRequestBranch;
+
+    const JSON: &str = r#"
+    {
+        "ref": "main",
+        "sha": "3de05046636de664eff97823e24c92d382fa6607",
+        "repo": {
+            "id": 518377950,
+            "url": "https://api.github.com/repos/devxbots/automatons",
+            "name": "automatons"
+        }
+    }
+    "#;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let branch: PullRequestBranch = serde_json::from_str(JSON).unwrap();
+
+        assert_eq!("main", branch.git_ref());
+    }
+
+    #[test]
+    fn trait_display() {
+        let branch: PullRequestBranch = serde_json::from_str(JSON).unwrap();
+
+        assert_eq!("main", branch.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PullRequestBranch>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<PullRequestBranch>();
+    }
+}

--- a/automatons-github/src/resource/pull_request/mod.rs
+++ b/automatons-github/src/resource/pull_request/mod.rs
@@ -1,0 +1,117 @@
+use std::fmt::{Display, Formatter};
+
+use url::Url;
+
+use crate::id;
+
+pub use self::branch::PullRequestBranch;
+
+mod branch;
+
+id!(
+    /// Pull request id
+    ///
+    /// The [`PullRequestId`] is a unique, numerical id that is used to interact with a pull request
+    /// through [GitHub's REST API](https://docs.github.com/en/rest).
+    PullRequestId
+);
+
+id!(
+    /// Pull request number
+    ///
+    /// Every [`PullRequest`] has a unique, human-readable, monotonically increasing number assigned
+    /// to it. This number identifies the pull request on GitHub's website.
+    PullRequestNumber
+);
+
+/// Pull request
+///
+/// Pull requests are a feature of GitHub to merge two branches. Users can create, review, and merge
+/// pull requests using GitHub's platform. Each pull request has a unique `id`, a human-readable
+/// `number`, and references to the two branches.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct PullRequest {
+    id: PullRequestId,
+    number: PullRequestNumber,
+    url: Url,
+    head: PullRequestBranch,
+    base: PullRequestBranch,
+}
+
+impl PullRequest {
+    /// Returns the pull request's id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn id(&self) -> PullRequestId {
+        self.id
+    }
+
+    /// Returns the pull request's number.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn number(&self) -> PullRequestNumber {
+        self.number
+    }
+
+    /// Returns the API endpoint to query the pull request.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Returns the pull request's head branch
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn head(&self) -> &PullRequestBranch {
+        &self.head
+    }
+
+    /// Returns the pull request's base branch
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn base(&self) -> &PullRequestBranch {
+        &self.base
+    }
+}
+
+impl Display for PullRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{}", self.number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PullRequest;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let pr: PullRequest = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/resource/pull_request.json"
+        ))
+        .unwrap();
+
+        assert_eq!(27, pr.number().get());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_display() {
+        let pr: PullRequest = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/resource/pull_request.json"
+        ))
+        .unwrap();
+
+        assert_eq!("#27", pr.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<PullRequest>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<PullRequest>();
+    }
+}

--- a/automatons-github/tests/fixtures/resource/pull_request.json
+++ b/automatons-github/tests/fixtures/resource/pull_request.json
@@ -1,0 +1,23 @@
+{
+  "id": 1017334309,
+  "number": 27,
+  "url": "https://api.github.com/repos/devxbots/automatons/pulls/27",
+  "head": {
+    "ref": "create-app-resource",
+    "sha": "7fb3254b029acb55db7f8134d1526a080cd63c48",
+    "repo": {
+      "id": 518377950,
+      "url": "https://api.github.com/repos/devxbots/automatons",
+      "name": "automatons"
+    }
+  },
+  "base": {
+    "ref": "main",
+    "sha": "3de05046636de664eff97823e24c92d382fa6607",
+    "repo": {
+      "id": 518377950,
+      "url": "https://api.github.com/repos/devxbots/automatons",
+      "name": "automatons"
+    }
+  }
+}


### PR DESCRIPTION
Pull requests are a feature of GitHub to merge two branches. They give users the opportunity to review and comment on each other's code, and perform automated tests before merging. A new resource has been created for them.