### PR TITLE
Create resource for check suites

### DIFF
--- a/automatons-github/src/resource/check_run/conclusion.rs
+++ b/automatons-github/src/resource/check_run/conclusion.rs
@@ -1,0 +1,84 @@
+use std::fmt::{Display, Formatter};
+
+/// Check run conclusion
+///
+/// When a check run finishes, its conclusion indicates the success or failure of the check run to
+/// the user. Branch protection rules can be created to require a successful conclusion before code
+/// can be merged into a branch.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum CheckRunConclusion {
+    /// Check run finished successfully
+    Success,
+
+    /// Check run failed
+    Failure,
+
+    /// Check run finished in a neutral state
+    Neutral,
+
+    /// Check run was skipped
+    Skipped,
+
+    /// Check run was cancelled
+    Cancelled,
+
+    /// Check run timed out
+    TimedOut,
+
+    /// Check run requested an action from the user
+    ActionRequired,
+
+    /// Check run was marked as stable by GitHub
+    Stale,
+}
+
+impl Display for CheckRunConclusion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string_representation = match self {
+            CheckRunConclusion::Success => "success",
+            CheckRunConclusion::Failure => "failure",
+            CheckRunConclusion::Neutral => "neutral",
+            CheckRunConclusion::Skipped => "skipped",
+            CheckRunConclusion::Cancelled => "cancelled",
+            CheckRunConclusion::TimedOut => "timed out",
+            CheckRunConclusion::ActionRequired => "action required",
+            CheckRunConclusion::Stale => "stale",
+        };
+
+        write!(f, "{}", string_representation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunConclusion;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let conclusion: CheckRunConclusion = serde_json::from_str(r#""action_required""#).unwrap();
+
+        assert!(matches!(conclusion, CheckRunConclusion::ActionRequired));
+    }
+
+    #[test]
+    fn trait_display() {
+        let conclusion = CheckRunConclusion::ActionRequired;
+
+        assert_eq!("action required", conclusion.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunConclusion>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunConclusion>();
+    }
+}

--- a/automatons-github/src/resource/check_run/mod.rs
+++ b/automatons-github/src/resource/check_run/mod.rs
@@ -1,0 +1,5 @@
+pub use self::conclusion::CheckRunConclusion;
+pub use self::status::CheckRunStatus;
+
+mod conclusion;
+mod status;

--- a/automatons-github/src/resource/check_run/status.rs
+++ b/automatons-github/src/resource/check_run/status.rs
@@ -1,0 +1,64 @@
+use std::fmt::{Display, Formatter};
+
+/// Check run status
+///
+/// Check runs can be in one of three states. When a check run is created, the status is `queued`.
+/// Once its dependencies are ready and the execution starts, the status changes to `in progress`.
+/// Finally, the check run is finished and the status is set to `completed`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum CheckRunStatus {
+    /// Queued state
+    Queued,
+
+    /// In progress state
+    InProgress,
+
+    /// Completed state
+    Completed,
+}
+
+impl Display for CheckRunStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string_representation = match self {
+            CheckRunStatus::Queued => "queued",
+            CheckRunStatus::InProgress => "in progress",
+            CheckRunStatus::Completed => "completed",
+        };
+
+        write!(f, "{}", string_representation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunStatus;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let status: CheckRunStatus = serde_json::from_str(r#""in_progress""#).unwrap();
+
+        assert!(matches!(status, CheckRunStatus::InProgress));
+    }
+
+    #[test]
+    fn trait_display() {
+        let status = CheckRunStatus::InProgress;
+
+        assert_eq!("in progress", status.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunStatus>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunStatus>();
+    }
+}

--- a/automatons-github/src/resource/check_suite.rs
+++ b/automatons-github/src/resource/check_suite.rs
@@ -1,0 +1,166 @@
+use std::fmt::{Display, Formatter};
+
+use chrono::{DateTime, Utc};
+use url::Url;
+
+use crate::id;
+use crate::resource::{App, CheckRunConclusion, CheckRunStatus, NodeId, PullRequest};
+
+id!(
+    /// Check suite id
+    ///
+    /// The [`CheckSuiteId`] is a unique, numerical id that is used to interact with a check suite
+    /// through [GitHub's REST API](https://docs.github.com/en/rest).
+    CheckSuiteId
+);
+
+/// Check suite
+///
+/// When someone pushes code to a repository, GitHub creates a check suite for the last commit. A
+/// check suite is a collection of the check runs created by a single GitHub App for a specific
+/// commit. Check suites summarize the status and conclusion of the check runs that a suite
+/// includes.
+///
+/// Read more: https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api
+#[derive(Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct CheckSuite {
+    id: CheckSuiteId,
+    node_id: NodeId,
+    head_branch: String,
+    head_sha: String,
+    status: CheckRunStatus,
+    conclusion: Option<CheckRunConclusion>,
+    url: Url,
+    before: String,
+    after: String,
+    pull_requests: Vec<PullRequest>,
+    app: App,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl CheckSuite {
+    /// Returns the check suite's id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn id(&self) -> CheckSuiteId {
+        self.id
+    }
+
+    /// Returns the check suite's node id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    /// Returns the check suite's head branch.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn head_branch(&self) -> &str {
+        &self.head_branch
+    }
+
+    /// Returns the check suite's head SHA.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn head_sha(&self) -> &str {
+        &self.head_sha
+    }
+
+    /// Returns the check suite's status
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn status(&self) -> CheckRunStatus {
+        self.status
+    }
+
+    /// Returns the check suite's conclusion.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn conclusion(&self) -> Option<CheckRunConclusion> {
+        self.conclusion
+    }
+
+    /// Returns the API endpoint to query the check suite.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Returns the check suite's parent commit.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn before(&self) -> &str {
+        &self.before
+    }
+
+    /// Returns the check suite's head commit.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn after(&self) -> &str {
+        &self.after
+    }
+
+    /// Returns the check suite's pull requests.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn pull_requests(&self) -> &Vec<PullRequest> {
+        &self.pull_requests
+    }
+
+    /// Returns the check suite's app.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn app(&self) -> &App {
+        &self.app
+    }
+
+    /// Returns the date when the check suite was created.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn created_at(&self) -> &DateTime<Utc> {
+        &self.created_at
+    }
+
+    /// Returns the date when the check suite was last updated.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn updated_at(&self) -> &DateTime<Utc> {
+        &self.updated_at
+    }
+}
+
+impl Display for CheckSuite {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckSuite;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_deserialize() {
+        let suite: CheckSuite = serde_json::from_str(include_str!(
+            "../../tests/fixtures/resource/check_suite.json"
+        ))
+        .unwrap();
+
+        assert_eq!(7663255123, suite.id().get());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn trait_display() {
+        let suite: CheckSuite = serde_json::from_str(include_str!(
+            "../../tests/fixtures/resource/check_suite.json"
+        ))
+        .unwrap();
+
+        assert_eq!("7663255123", suite.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckSuite>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckSuite>();
+    }
+}

--- a/automatons-github/src/resource/mod.rs
+++ b/automatons-github/src/resource/mod.rs
@@ -10,6 +10,8 @@ use crate::name;
 
 pub use self::account::{Account, AccountId, AccountType, Login};
 pub use self::app::{App, AppId, AppName, AppSlug};
+pub use self::check_run::{CheckRunConclusion, CheckRunStatus};
+pub use self::check_suite::CheckSuite;
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
 pub use self::organization::{Organization, OrganizationId};
@@ -21,6 +23,8 @@ pub use self::visibility::Visibility;
 
 mod account;
 mod app;
+mod check_run;
+mod check_suite;
 mod installation;
 mod license;
 mod organization;

--- a/automatons-github/tests/fixtures/resource/check_suite.json
+++ b/automatons-github/tests/fixtures/resource/check_suite.json
@@ -1,0 +1,123 @@
+{
+  "id": 7663255123,
+  "node_id": "CS_kwDOHuXR3s8AAAAByMP-Uw",
+  "head_branch": "create-app-resource",
+  "head_sha": "7fb3254b029acb55db7f8134d1526a080cd63c48",
+  "status": "in_progress",
+  "conclusion": null,
+  "url": "https://api.github.com/repos/devxbots/automatons/check-suites/7663255123",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "7fb3254b029acb55db7f8134d1526a080cd63c48",
+  "pull_requests": [
+    {
+      "url": "https://api.github.com/repos/devxbots/automatons/pulls/27",
+      "id": 1017334309,
+      "number": 27,
+      "head": {
+        "ref": "create-app-resource",
+        "sha": "7fb3254b029acb55db7f8134d1526a080cd63c48",
+        "repo": {
+          "id": 518377950,
+          "url": "https://api.github.com/repos/devxbots/automatons",
+          "name": "automatons"
+        }
+      },
+      "base": {
+        "ref": "main",
+        "sha": "3de05046636de664eff97823e24c92d382fa6607",
+        "repo": {
+          "id": 518377950,
+          "url": "https://api.github.com/repos/devxbots/automatons",
+          "name": "automatons"
+        }
+      }
+    }
+  ],
+  "app": {
+    "id": 15368,
+    "slug": "github-actions",
+    "node_id": "MDM6QXBwMTUzNjg=",
+    "owner": {
+      "login": "github",
+      "id": 9919,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/github",
+      "html_url": "https://github.com/github",
+      "followers_url": "https://api.github.com/users/github/followers",
+      "following_url": "https://api.github.com/users/github/following{/other_user}",
+      "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+      "organizations_url": "https://api.github.com/users/github/orgs",
+      "repos_url": "https://api.github.com/users/github/repos",
+      "events_url": "https://api.github.com/users/github/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/github/received_events",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "name": "GitHub Actions",
+    "description": "Automate your workflow from idea to production",
+    "external_url": "https://help.github.com/en/actions",
+    "html_url": "https://github.com/apps/github-actions",
+    "created_at": "2018-07-30T09:30:17Z",
+    "updated_at": "2019-12-10T19:04:12Z",
+    "permissions": {
+      "actions": "write",
+      "administration": "read",
+      "checks": "write",
+      "contents": "write",
+      "deployments": "write",
+      "discussions": "write",
+      "issues": "write",
+      "merge_queues": "write",
+      "metadata": "read",
+      "packages": "write",
+      "pages": "write",
+      "pull_requests": "write",
+      "repository_hooks": "write",
+      "repository_projects": "write",
+      "security_events": "write",
+      "statuses": "write",
+      "vulnerability_alerts": "read"
+    },
+    "events": [
+      "branch_protection_rule",
+      "check_run",
+      "check_suite",
+      "create",
+      "delete",
+      "deployment",
+      "deployment_status",
+      "discussion",
+      "discussion_comment",
+      "fork",
+      "gollum",
+      "issues",
+      "issue_comment",
+      "label",
+      "merge_group",
+      "milestone",
+      "page_build",
+      "project",
+      "project_card",
+      "project_column",
+      "public",
+      "pull_request",
+      "pull_request_review",
+      "pull_request_review_comment",
+      "push",
+      "registry_package",
+      "release",
+      "repository",
+      "repository_dispatch",
+      "status",
+      "watch",
+      "workflow_dispatch",
+      "workflow_run"
+    ]
+  },
+  "created_at": "2022-08-04T10:14:12Z",
+  "updated_at": "2022-08-04T10:14:25Z"
+}


### PR DESCRIPTION
Check suites are created when a user pushes code to GitHub, and they summarize the status and conclusion of the check runs that they include. A new resource has been created that represents a check suite, and enumerations have been added for the status and conclusion of check runs.