### PR TITLE
Enable funding

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+---
+github: jdno


### PR DESCRIPTION
Users can support the project financially by sponsoring @jdno. Besides providing emotional support, this will help us offer a free hosted service to open source projects.