### PR TITLE
Create types for Git references and SHAs

### DIFF
--- a/automatons-github/src/resource/check_run/mod.rs
+++ b/automatons-github/src/resource/check_run/mod.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer};
 use url::Url;
 
-use crate::resource::{App, CheckSuite, NodeId, PullRequest};
+use crate::resource::{App, CheckSuite, GitSha, NodeId, PullRequest};
 use crate::{id, name};
 
 pub use self::conclusion::CheckRunConclusion;
@@ -41,7 +41,7 @@ pub struct CheckRun {
     id: CheckRunId,
     node_id: NodeId,
     name: CheckRunName,
-    head_sha: String,
+    head_sha: GitSha,
     external_id: String,
     url: Url,
     html_url: Url,
@@ -79,7 +79,7 @@ impl CheckRun {
 
     /// Returns the check run's head SHA.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn head_sha(&self) -> &str {
+    pub fn head_sha(&self) -> &GitSha {
         &self.head_sha
     }
 

--- a/automatons-github/src/resource/check_suite.rs
+++ b/automatons-github/src/resource/check_suite.rs
@@ -4,7 +4,9 @@ use chrono::{DateTime, Utc};
 use url::Url;
 
 use crate::id;
-use crate::resource::{App, CheckRunConclusion, CheckRunStatus, NodeId, PullRequest};
+use crate::resource::{
+    App, CheckRunConclusion, CheckRunStatus, GitRef, GitSha, NodeId, PullRequest,
+};
 
 id!(
     /// Check suite id
@@ -27,13 +29,13 @@ id!(
 pub struct CheckSuite {
     id: CheckSuiteId,
     node_id: NodeId,
-    head_branch: String,
-    head_sha: String,
+    head_branch: GitRef,
+    head_sha: GitSha,
     status: CheckRunStatus,
     conclusion: Option<CheckRunConclusion>,
     url: Url,
-    before: String,
-    after: String,
+    before: GitSha,
+    after: GitSha,
     pull_requests: Vec<PullRequest>,
     app: App,
     created_at: DateTime<Utc>,
@@ -55,13 +57,13 @@ impl CheckSuite {
 
     /// Returns the check suite's head branch.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn head_branch(&self) -> &str {
+    pub fn head_branch(&self) -> &GitRef {
         &self.head_branch
     }
 
     /// Returns the check suite's head SHA.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn head_sha(&self) -> &str {
+    pub fn head_sha(&self) -> &GitSha {
         &self.head_sha
     }
 
@@ -85,13 +87,13 @@ impl CheckSuite {
 
     /// Returns the check suite's parent commit.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn before(&self) -> &str {
+    pub fn before(&self) -> &GitSha {
         &self.before
     }
 
     /// Returns the check suite's head commit.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn after(&self) -> &str {
+    pub fn after(&self) -> &GitSha {
         &self.after
     }
 

--- a/automatons-github/src/resource/git.rs
+++ b/automatons-github/src/resource/git.rs
@@ -1,0 +1,20 @@
+use crate::name;
+
+name!(
+    /// Git reference
+    ///
+    /// A Git reference (git ref) is a file that contains a Git commit SHA-1 hash. When referring to
+    /// a Git commit, you can use the Git reference, which is an easy-to-remember name, rather than
+    /// the hash.
+    ///
+    /// Read more: https://docs.github.com/en/rest/git/refs
+    GitRef
+);
+
+name!(
+    /// Git commit SHA-1
+    ///
+    /// Commits in Git are uniquely identified by their SHA-1 hash, which is used throughout
+    /// GitHub's API to reference commits in the Git database.
+    GitSha
+);

--- a/automatons-github/src/resource/mod.rs
+++ b/automatons-github/src/resource/mod.rs
@@ -15,6 +15,7 @@ pub use self::check_run::{
     CheckRunOutputTitle, CheckRunStatus,
 };
 pub use self::check_suite::CheckSuite;
+pub use self::git::{GitRef, GitSha};
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
 pub use self::organization::{Organization, OrganizationId};
@@ -28,6 +29,7 @@ mod account;
 mod app;
 mod check_run;
 mod check_suite;
+mod git;
 mod installation;
 mod license;
 mod organization;

--- a/automatons-github/src/resource/pull_request/branch.rs
+++ b/automatons-github/src/resource/pull_request/branch.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use crate::resource::MinimalRepository;
+use crate::resource::{GitRef, GitSha, MinimalRepository};
 
 /// Pull request branch reference
 ///
@@ -11,10 +11,10 @@ use crate::resource::MinimalRepository;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PullRequestBranch {
     #[cfg_attr(feature = "serde", serde(rename = "ref"))]
-    git_ref: String,
+    git_ref: GitRef,
 
     #[cfg_attr(feature = "serde", serde(rename = "sha"))]
-    git_sha: String,
+    git_sha: GitSha,
 
     repo: MinimalRepository,
 }
@@ -22,13 +22,13 @@ pub struct PullRequestBranch {
 impl PullRequestBranch {
     /// Returns the pull request branch's git ref.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn git_ref(&self) -> &str {
+    pub fn git_ref(&self) -> &GitRef {
         &self.git_ref
     }
 
     /// Returns the pull request branch's git sha.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn git_sha(&self) -> &str {
+    pub fn git_sha(&self) -> &GitSha {
         &self.git_sha
     }
 
@@ -66,7 +66,7 @@ mod test {
     fn trait_deserialize() {
         let branch: PullRequestBranch = serde_json::from_str(JSON).unwrap();
 
-        assert_eq!("main", branch.git_ref());
+        assert_eq!("main", branch.git_ref().get());
     }
 
     #[test]


### PR DESCRIPTION
Two newtypes have been created for Git references and commit hashes. Both are used as identifiers throughout the GitHub platform, and using a dedicated type for them ensures that they are not passed by accident to the wrong API endpoint.