### PR TITLE
Bump automatons-github from 0.0.0 to 0.1.0

### DIFF
--- a/automatons-github/Cargo.toml
+++ b/automatons-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automatons-github"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 description = "GitHub integration for the automatons framework"


### PR DESCRIPTION
The initial release of the GitHub integration for the automatons framework adds the `check_run` event and the resources in its payload.