### PR TITLE
Create Lambda function for GitHub ingress

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -23,6 +23,9 @@
 - name: P-automatons-github
   color: f1c40f
   description: "Tag the automatons-github package"
+- name: P-automatons-ingress-github
+  color: f1c40f
+  description: "Tag the automatons-ingress-github package"
 - name: R-added
   color: 95a5a6
   description: "Add a new feature to the release notes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "automatons",
     "automatons-github",
+    "automatons-ingress-github",
 ]

--- a/automatons-ingress-github/Cargo.toml
+++ b/automatons-ingress-github/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "automatons-ingress-github"
+version = "0.0.0"
+edition = "2021"
+
+description = "Ingress for events from GitHub"
+repository = "https://github.com/devxbots/automatons"
+license = "MIT OR Apache-2.0"
+
+categories = [
+    "development-tools"
+]
+keywords = [
+    "github",
+    "github-app",
+]
+
+# See more keys and their definitions at
+# https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lambda_http = { version = "0.6.0", default-features = false, features = ["apigw_rest"] }
+lambda_runtime = "0.6.0"
+tokio = { version = "1.20.1", features = ["macros"] }
+tracing = { version = "0.1.36", features = ["log"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = ["fmt"] }

--- a/automatons-ingress-github/src/main.rs
+++ b/automatons-ingress-github/src/main.rs
@@ -1,0 +1,22 @@
+use lambda_http::{run, service_fn, Body, Error, Request, Response};
+
+async fn function_handler(_event: Request) -> Result<Response<Body>, Error> {
+    let response = Response::builder()
+        .status(200)
+        .header("content-type", "text/html")
+        .body("Hello AWS Lambda HTTP request".into())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    run(service_fn(function_handler)).await
+}


### PR DESCRIPTION
Ingress endpoints allow third-party integrations to publish events that will be processed by the automatons platform. For GitHub, the ingress is build as an AWS Lambda function that will verify incoming webhooks and push their event into an AWS SQS queue. A new Rust crate has been created that will contain the source code of this function.