### PR TITLE
Return a Result from the task's init function

### DIFF
--- a/automatons/src/task.rs
+++ b/automatons/src/task.rs
@@ -30,7 +30,7 @@ pub trait Task: Send + Sync {
     ///
     /// Tasks are initialized by the engine when the previous task has finished successfully. If
     /// they need any data, they can retrieve it from the shared state.
-    fn init(state: &State) -> Box<dyn Task>
+    fn init(state: &State) -> Result<Box<dyn Task>, Error>
     where
         Self: Sized;
 

--- a/automatons/tests/hello-world.rs
+++ b/automatons/tests/hello-world.rs
@@ -32,11 +32,11 @@ impl Automaton for HelloWorld {
 
 #[async_trait]
 impl Task for Hello {
-    fn init(_state: &State) -> Box<dyn Task>
+    fn init(_state: &State) -> Result<Box<dyn Task>, Error>
     where
         Self: Sized,
     {
-        Box::new(Hello)
+        Ok(Box::new(Hello))
     }
 
     async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
@@ -47,11 +47,11 @@ impl Task for Hello {
 
 #[async_trait]
 impl Task for World {
-    fn init(_state: &State) -> Box<dyn Task>
+    fn init(_state: &State) -> Result<Box<dyn Task>, Error>
     where
         Self: Sized,
     {
-        Box::new(World)
+        Ok(Box::new(World))
     }
 
     async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {


### PR DESCRIPTION
The `init` function for a `Task` has been refactored to return a `Result`. This makes it possible to initialize the task from the state, and gracefully handle missing values.