### PR TITLE
Simplify task initialization

### DIFF
--- a/automatons/src/lib.rs
+++ b/automatons/src/lib.rs
@@ -14,7 +14,7 @@ mod task;
 ///
 /// Automatons execute a series of tasks. The tasks are provided as a list of constructor functions
 /// so that the automaton can initialize the tasks one by one.
-pub type Tasks = Vec<Box<dyn Fn(&State) -> Result<Box<dyn Task>, Error> + Send + Sync>>;
+pub type Tasks = Vec<Box<dyn Task + Send + Sync>>;
 
 /// Trait for automatons
 ///
@@ -42,8 +42,8 @@ pub trait Automaton: Debug {
     /// task is executed. This can be useful to perform any teardown actions, for example to remove
     /// resources that were created in a previous step. By default, a "noop" task is executed that
     /// performs no action.
-    fn complete_task(&self, state: &State) -> Result<Box<dyn Task>, Error> {
-        NoopTask::init(state)
+    fn complete_task(&self) -> Box<dyn Task> {
+        Box::new(NoopTask)
     }
 
     /// Executes the automaton.
@@ -57,8 +57,7 @@ pub trait Automaton: Debug {
     async fn execute(&self) -> Result<State, Error> {
         let mut state = self.initial_state();
 
-        for task_init_fn in self.tasks().iter() {
-            let mut task = task_init_fn(&state)?;
+        for task in self.tasks().iter_mut() {
             let transition = task.execute(&mut state).await?;
 
             match transition {
@@ -67,7 +66,7 @@ pub trait Automaton: Debug {
             }
         }
 
-        let mut complete_task = self.complete_task(&state)?;
+        let mut complete_task = self.complete_task();
         complete_task.execute(&mut state).await?;
 
         Ok(state)
@@ -79,14 +78,6 @@ struct NoopTask;
 
 #[async_trait]
 impl Task for NoopTask {
-    #[cfg_attr(feature = "tracing", tracing::instrument)]
-    fn init(_state: &State) -> Result<Box<dyn Task>, Error>
-    where
-        Self: Sized,
-    {
-        Ok(Box::new(NoopTask))
-    }
-
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     async fn execute(&mut self, _state: &mut State) -> Result<Transition, Error> {
         Ok(Transition::Complete)

--- a/automatons/src/task.rs
+++ b/automatons/src/task.rs
@@ -26,14 +26,6 @@ pub enum Transition {
 /// [`Transition`] with the `Complete` variant.
 #[async_trait]
 pub trait Task: Send + Sync {
-    /// Initializes a new instance of the task.
-    ///
-    /// Tasks are initialized by the engine when the previous task has finished successfully. If
-    /// they need any data, they can retrieve it from the shared state.
-    fn init(state: &State) -> Result<Box<dyn Task>, Error>
-    where
-        Self: Sized;
-
     /// Executes the task.
     ///
     /// Tasks can perform arbitrary units of work. They are executed asynchronously to avoid

--- a/automatons/tests/hello-world.rs
+++ b/automatons/tests/hello-world.rs
@@ -16,29 +16,25 @@ async fn test() -> Result<(), Error> {
 // Return type
 #[derive(Debug)]
 struct Message(String);
+
 // Automaton
 #[derive(Debug)]
 struct HelloWorld;
+
 // Task
 struct Hello;
+
 // Task
 struct World;
 
 impl Automaton for HelloWorld {
     fn tasks(&self) -> Tasks {
-        vec![Box::new(Hello::init), Box::new(World::init)]
+        vec![Box::new(Hello), Box::new(World)]
     }
 }
 
 #[async_trait]
 impl Task for Hello {
-    fn init(_state: &State) -> Result<Box<dyn Task>, Error>
-    where
-        Self: Sized,
-    {
-        Ok(Box::new(Hello))
-    }
-
     async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
         state.insert(Message(String::from("Hello")));
         Ok(Transition::Next)
@@ -47,13 +43,6 @@ impl Task for Hello {
 
 #[async_trait]
 impl Task for World {
-    fn init(_state: &State) -> Result<Box<dyn Task>, Error>
-    where
-        Self: Sized,
-    {
-        Ok(Box::new(World))
-    }
-
     async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
         let message: &mut Message = state
             .get_mut()


### PR DESCRIPTION
The initialization of tasks has been simplified by removing the `init` method. The initial ideas was that tasks can be initialized from the state, but in practice this caused issues when a task wanted to keep references to data in the state. We are thus falling back to a simpler implementation that reduces the `Task` trait to the `execute` method. Tasks can initialize the data they need in that method, which removes any issues with lifetimes.