### PR TITLE
Remove optional features from GitHub crate

### DIFF
--- a/automatons-github/Cargo.toml
+++ b/automatons-github/Cargo.toml
@@ -15,38 +15,21 @@ keywords = [
     "github-app",
 ]
 
-[features]
-client = [
-    "dep:anyhow",
-    "dep:jsonwebtoken",
-    "dep:parking_lot",
-    "dep:reqwest",
-    "dep:secrecy",
-    "dep:thiserror",
-    "serde",
-]
-serde = [
-    "dep:serde",
-    "dep:serde_json",
-    "chrono/serde",
-    "url/serde",
-]
-
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.60", optional = true }
-chrono = "0.4.19"
-jsonwebtoken = { version = "8.1.1", optional = true }
-parking_lot = { version = "0.12.1", optional = true }
-reqwest = { version = "0.11.11", optional = true, features = ["json"] }
-secrecy = { version = "0.8.0", optional = true }
-serde = { version = "1.0.141", optional = true, features = ["derive"] }
-serde_json = { version = "1.0.83", optional = true }
-thiserror = { version = "1.0.32", optional = true }
+anyhow = { version = "1.0.60" }
+chrono = { version = "0.4.19", features = ["serde"] }
+jsonwebtoken = { version = "8.1.1" }
+parking_lot = { version = "0.12.1" }
+reqwest = { version = "0.11.11", features = ["json"] }
+secrecy = { version = "0.8.0" }
+serde = { version = "1.0.141", features = ["derive"] }
+serde_json = { version = "1.0.83" }
+thiserror = { version = "1.0.32" }
 tracing = { version = "0.1.36", optional = true }
-url = "2.2.2"
+url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/automatons-github/src/event/check_run.rs
+++ b/automatons-github/src/event/check_run.rs
@@ -1,13 +1,14 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 use crate::resource::{Account, CheckRun, Installation, Organization, Repository};
 
 /// Check run action
 ///
 /// The type of activity that has occurred.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CheckRunAction {
     /// A new check run was created.
     Created,
@@ -28,8 +29,7 @@ pub enum CheckRunAction {
 /// repository that the check run was created in. If the webhook was configured for an organization,
 /// or if the repository is owned by one, the organization is included in the payload. If the event
 /// is sent to a GitHub App, the payload contains the installation.
-#[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct CheckRunEvent {
     action: CheckRunAction,
     check_run: CheckRun,
@@ -101,7 +101,6 @@ mod tests {
     use super::{CheckRunAction, CheckRunEvent};
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let check_run_event: CheckRunEvent = serde_json::from_str(include_str!(
             "../../tests/fixtures/event/check_run.completed.json"
@@ -115,7 +114,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let check_run_event: CheckRunEvent = serde_json::from_str(include_str!(
             "../../tests/fixtures/event/check_run.completed.json"

--- a/automatons-github/src/event/mod.rs
+++ b/automatons-github/src/event/mod.rs
@@ -9,6 +9,8 @@
 
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 pub use self::check_run::{CheckRunAction, CheckRunEvent};
 
 mod check_run;
@@ -24,9 +26,8 @@ mod check_run;
 /// Read more: https://docs.github.com/en/developers/webhooks-and-events/webhooks/about-webhooks
 ///
 /// The webhook payloads are inside a [`Box`], since their sizes vary greatly.
-#[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum GitHubEvent {
     /// Check run event
     CheckRun(Box<CheckRunEvent>),
@@ -57,7 +58,6 @@ mod tests {
     use super::GitHubEvent;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize_check_run() {
         let github_event: GitHubEvent = serde_json::from_str(include_str!(
             "../../tests/fixtures/event/check_run.completed.json"

--- a/automatons-github/src/macros.rs
+++ b/automatons-github/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! id {
     ) => {
         $(#[$meta])*
         #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(serde::Deserialize, serde::Serialize)]
         pub struct $id(u64);
 
         impl $id {
@@ -77,7 +77,7 @@ macro_rules! name {
     ) => {
         $(#[$meta])*
         #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(serde::Deserialize, serde::Serialize)]
         pub struct $name(String);
 
         impl $name {

--- a/automatons-github/src/resource/account.rs
+++ b/automatons-github/src/resource/account.rs
@@ -1,4 +1,6 @@
 use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::resource::NodeId;
@@ -26,8 +28,7 @@ name!(
 /// Bots represent (third-party) integrations with the platform, often driven by GitHub Apps.
 /// Organizations provide a space for users to collaborate and share resources. And user accounts
 /// represent the humans that build software on GitHub.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub enum AccountType {
     /// Bot account
     Bot,
@@ -45,8 +46,7 @@ pub enum AccountType {
 /// representation of three other resources: bots, users, and organizations. They provide a unified
 /// interface to information that is shared between all account types, and hide a lot of information
 /// that would unnecessarily increase payload sizes.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct Account {
     login: Login,
     id: AccountId,
@@ -65,7 +65,7 @@ pub struct Account {
     received_events_url: Url,
     site_admin: bool,
 
-    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    #[serde(rename = "type")]
     account_type: AccountType,
 }
 
@@ -175,8 +175,9 @@ impl Display for Account {
 
 #[cfg(test)]
 mod tests {
-    use crate::resource::account::AccountType;
     use url::{ParseError, Url};
+
+    use crate::resource::account::AccountType;
 
     use super::Account;
 
@@ -204,7 +205,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let json = r#"
         {

--- a/automatons-github/src/resource/app.rs
+++ b/automatons-github/src/resource/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::resource::{Account, NodeId};
@@ -35,8 +36,7 @@ name!(
 /// Third-parties can create integrations with the GitHub platform by creating a GitHub App. Apps
 /// have their own identify and authentication, and can request granular permissions and access to
 /// events. Every [`App`] is owned by an [`Account`].
-#[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct App {
     id: AppId,
     node_id: NodeId,
@@ -137,7 +137,6 @@ mod tests {
     use super::App;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let app: App =
             serde_json::from_str(include_str!("../../tests/fixtures/resource/app.json")).unwrap();
@@ -146,7 +145,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let app: App =
             serde_json::from_str(include_str!("../../tests/fixtures/resource/app.json")).unwrap();

--- a/automatons-github/src/resource/check_run/conclusion.rs
+++ b/automatons-github/src/resource/check_run/conclusion.rs
@@ -1,13 +1,14 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 /// Check run conclusion
 ///
 /// When a check run finishes, its conclusion indicates the success or failure of the check run to
 /// the user. Branch protection rules can be created to require a successful conclusion before code
 /// can be merged into a branch.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CheckRunConclusion {
     /// Check run finished successfully
     Success,
@@ -56,7 +57,6 @@ mod tests {
     use super::CheckRunConclusion;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let conclusion: CheckRunConclusion = serde_json::from_str(r#""action_required""#).unwrap();
 

--- a/automatons-github/src/resource/check_run/mod.rs
+++ b/automatons-github/src/resource/check_run/mod.rs
@@ -1,8 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, Utc};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
 use crate::resource::{App, CheckSuite, GitSha, NodeId, PullRequest};
@@ -35,8 +34,7 @@ name!(
 ///
 /// A check run is an individual test that is part of a check suite. Each run includes a status and
 /// conclusion.
-#[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct CheckRun {
     id: CheckRunId,
     node_id: NodeId,
@@ -54,7 +52,7 @@ pub struct CheckRun {
     app: App,
     pull_requests: Vec<PullRequest>,
 
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_output"))]
+    #[serde(deserialize_with = "deserialize_output")]
     output: Option<CheckRunOutput>,
 }
 
@@ -162,7 +160,6 @@ impl Display for CheckRun {
     }
 }
 
-#[cfg(feature = "serde")]
 fn deserialize_output<'de, D>(deserializer: D) -> Result<Option<CheckRunOutput>, D::Error>
 where
     D: Deserializer<'de>,
@@ -190,7 +187,6 @@ mod tests {
     use super::CheckRun;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let check_run: CheckRun = serde_json::from_str(include_str!(
             "../../../tests/fixtures/resource/check_run.json"

--- a/automatons-github/src/resource/check_run/output.rs
+++ b/automatons-github/src/resource/check_run/output.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::name;
@@ -19,8 +20,7 @@ name!(
 /// Integrations can provide additional context for a completed check run in the check run's output.
 /// The output has a title and a summary, which supports Markdown. It can optionally have a text
 /// with more details, and annotations.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct CheckRunOutput {
     title: CheckRunOutputTitle,
     summary: CheckRunOutputSummary,
@@ -84,7 +84,6 @@ mod tests {
     "#;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let output: CheckRunOutput = serde_json::from_str(JSON).unwrap();
 

--- a/automatons-github/src/resource/check_run/status.rs
+++ b/automatons-github/src/resource/check_run/status.rs
@@ -1,13 +1,14 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 /// Check run status
 ///
 /// Check runs can be in one of three states. When a check run is created, the status is `queued`.
 /// Once its dependencies are ready and the execution starts, the status changes to `in progress`.
 /// Finally, the check run is finished and the status is set to `completed`.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CheckRunStatus {
     /// Queued state
     Queued,
@@ -36,7 +37,6 @@ mod tests {
     use super::CheckRunStatus;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let status: CheckRunStatus = serde_json::from_str(r#""in_progress""#).unwrap();
 

--- a/automatons-github/src/resource/check_suite.rs
+++ b/automatons-github/src/resource/check_suite.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::id;
@@ -24,8 +25,7 @@ id!(
 /// includes.
 ///
 /// Read more: https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api
-#[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct CheckSuite {
     id: CheckSuiteId,
     node_id: NodeId,
@@ -133,7 +133,6 @@ mod tests {
     use super::CheckSuite;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let suite: CheckSuite = serde_json::from_str(include_str!(
             "../../tests/fixtures/resource/check_suite.json"
@@ -144,7 +143,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let suite: CheckSuite = serde_json::from_str(include_str!(
             "../../tests/fixtures/resource/check_suite.json"

--- a/automatons-github/src/resource/installation.rs
+++ b/automatons-github/src/resource/installation.rs
@@ -1,6 +1,9 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
 use crate::id;
 use crate::resource::NodeId;
-use std::fmt::{Display, Formatter};
 
 id!(
     /// Installation id
@@ -15,8 +18,7 @@ id!(
 /// When a user adds a GitHub App to an account, a new app installation is created. The installation
 /// id can be used by the app to request a scoped access token that allows it to interact with the
 /// resources of the account.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct Installation {
     id: InstallationId,
     node_id: NodeId,
@@ -44,11 +46,11 @@ impl Display for Installation {
 
 #[cfg(test)]
 mod tests {
-    use super::{Installation, InstallationId};
     use crate::resource::NodeId;
 
+    use super::{Installation, InstallationId};
+
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let installation: Installation = serde_json::from_str(include_str!(
             "../../tests/fixtures/resource/installation.json"

--- a/automatons-github/src/resource/license.rs
+++ b/automatons-github/src/resource/license.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::name;
@@ -33,8 +34,7 @@ name!(
 /// GitHub tries to detect the license of a project automatically. It checks for a license file and
 /// matches that against a known list of licenses, or reads the license fields in the package's
 /// manifest, e.g. in `package.json` or `Cargo.toml`.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct License {
     key: LicenseKey,
     name: LicenseName,
@@ -83,13 +83,13 @@ impl Display for License {
 
 #[cfg(test)]
 mod tests {
-    use crate::resource::NodeId;
     use url::Url;
+
+    use crate::resource::NodeId;
 
     use super::{License, LicenseKey, LicenseName, SpdxId};
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let license: License =
             serde_json::from_str(include_str!("../../tests/fixtures/resource/license.json"))

--- a/automatons-github/src/resource/organization.rs
+++ b/automatons-github/src/resource/organization.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::id;
@@ -17,8 +18,7 @@ id!(
 ///
 /// Organizations enable users to collaborate and share resources with each other in a structured
 /// way. Organizations can have members, teams, repositories, and other resources.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct Organization {
     login: Login,
     id: OrganizationId,
@@ -119,7 +119,6 @@ mod tests {
     use super::Organization;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let organization: Organization = serde_json::from_str(include_str!(
             "../../tests/fixtures/resource/organization.json"
@@ -130,7 +129,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let organization: Organization = serde_json::from_str(include_str!(
             "../../tests/fixtures/resource/organization.json"

--- a/automatons-github/src/resource/pull_request/branch.rs
+++ b/automatons-github/src/resource/pull_request/branch.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 use crate::resource::{GitRef, GitSha, MinimalRepository};
 
 /// Pull request branch reference
@@ -7,13 +9,12 @@ use crate::resource::{GitRef, GitSha, MinimalRepository};
 /// Pull requests have a `base` branch against which they are opened, and a `head` branch that
 /// contains the changes that should be merged. The [`PullRequest`] resource references these using
 /// the [`PullRequestBranch`] data type.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct PullRequestBranch {
-    #[cfg_attr(feature = "serde", serde(rename = "ref"))]
+    #[serde(rename = "ref")]
     git_ref: GitRef,
 
-    #[cfg_attr(feature = "serde", serde(rename = "sha"))]
+    #[serde(rename = "sha")]
     git_sha: GitSha,
 
     repo: MinimalRepository,
@@ -62,7 +63,6 @@ mod test {
     "#;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let branch: PullRequestBranch = serde_json::from_str(JSON).unwrap();
 

--- a/automatons-github/src/resource/pull_request/mod.rs
+++ b/automatons-github/src/resource/pull_request/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::id;
@@ -29,8 +30,7 @@ id!(
 /// Pull requests are a feature of GitHub to merge two branches. Users can create, review, and merge
 /// pull requests using GitHub's platform. Each pull request has a unique `id`, a human-readable
 /// `number`, and references to the two branches.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct PullRequest {
     id: PullRequestId,
     number: PullRequestNumber,
@@ -82,7 +82,6 @@ mod tests {
     use super::PullRequest;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let pr: PullRequest = serde_json::from_str(include_str!(
             "../../../tests/fixtures/resource/pull_request.json"
@@ -93,7 +92,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let pr: PullRequest = serde_json::from_str(include_str!(
             "../../../tests/fixtures/resource/pull_request.json"

--- a/automatons-github/src/resource/repository/minimal.rs
+++ b/automatons-github/src/resource/repository/minimal.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::resource::{RepositoryId, RepositoryName};
@@ -8,8 +9,7 @@ use crate::resource::{RepositoryId, RepositoryName};
 ///
 /// GitHub truncates data types in some API responses and webhook events to reduce the payload size.
 /// The [`MinimalRepository`] represents a `[Repository`], but contains only the most basic fields.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct MinimalRepository {
     id: RepositoryId,
     name: RepositoryName,
@@ -77,7 +77,6 @@ mod tests {
     "#;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let repository: MinimalRepository = serde_json::from_str(JSON).unwrap();
 

--- a/automatons-github/src/resource/repository/mod.rs
+++ b/automatons-github/src/resource/repository/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::resource::{Account, License, NodeId, Visibility};
@@ -37,10 +38,9 @@ name!(
 ///
 /// Repositories are a core resource on GitHub, and most other resources belong to them. They are
 /// uniquely identified by the combination of their `owner` and `name`.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct Repository {
-    #[cfg_attr(feature = "serde", serde(flatten))]
+    #[serde(flatten)]
     minimal: MinimalRepository,
 
     node_id: NodeId,
@@ -566,7 +566,6 @@ mod tests {
     use super::Repository;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let repository: Repository = serde_json::from_str(include_str!(
             "../../../tests/fixtures/resource/repository.json"
@@ -577,7 +576,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_display() {
         let repository: Repository = serde_json::from_str(include_str!(
             "../../../tests/fixtures/resource/repository.json"

--- a/automatons-github/src/resource/visibility.rs
+++ b/automatons-github/src/resource/visibility.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use serde::{Deserialize, Serialize};
+
 /// Visibility of a resource
 ///
 /// Some resources on GitHub can be made available to different groups of people. Most prominently,
@@ -7,9 +9,8 @@ use std::fmt::{Display, Formatter};
 /// On [github.com](https://github.com), resources can either be `public` or `private`. On hosted
 /// GitHub Enterprise servers, `internal` resources can only be access by members of the same
 /// GitHub organization.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Visibility {
     /// Internal visibility
     ///
@@ -44,7 +45,6 @@ mod tests {
     use super::Visibility;
 
     #[test]
-    #[cfg(feature = "serde")]
     fn trait_deserialize() {
         let visibility: Visibility = serde_json::from_str(r#""internal""#).unwrap();
 


### PR DESCRIPTION
The crate for the GitHub integration had two optional features: `client` and `serde`. Both are required to implement tasks, so they have been removed and the dependencies are no longer optional.