### PR TITLE
Create task that lists check runs for a check suite

### DIFF
--- a/integrations/github/src/resource/check_run/mod.rs
+++ b/integrations/github/src/resource/check_run/mod.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
-use crate::resource::{App, CheckSuite, GitSha, NodeId, PullRequest};
+use crate::resource::{App, CheckSuite, Field, GitSha, MinimalCheckSuite, NodeId, PullRequest};
 use crate::{id, name};
 
 pub use self::conclusion::CheckRunConclusion;
@@ -48,7 +48,7 @@ pub struct CheckRun {
     conclusion: Option<CheckRunConclusion>,
     started_at: DateTime<Utc>,
     completed_at: Option<DateTime<Utc>>,
-    check_suite: CheckSuite,
+    check_suite: Field<MinimalCheckSuite, CheckSuite>,
     app: App,
     pull_requests: Vec<PullRequest>,
 
@@ -137,7 +137,7 @@ impl CheckRun {
 
     /// Returns the check run's check suite.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
-    pub fn check_suite(&self) -> &CheckSuite {
+    pub fn check_suite(&self) -> &Field<MinimalCheckSuite, CheckSuite> {
         &self.check_suite
     }
 

--- a/integrations/github/src/resource/check_suite/minimal.rs
+++ b/integrations/github/src/resource/check_suite/minimal.rs
@@ -1,0 +1,67 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use crate::resource::CheckSuiteId;
+
+/// Minimal representation of a [`CheckSuite`]
+///
+/// GitHub truncates data types in some API responses and webhook events to reduce the payload size.
+/// The [`MinimalCheckSuite`] represents a `[CheckSuite`], but contains only the most basic fields.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct MinimalCheckSuite {
+    id: CheckSuiteId,
+}
+
+impl MinimalCheckSuite {
+    /// Returns the check suite's id.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn id(&self) -> CheckSuiteId {
+        self.id
+    }
+}
+
+impl Display for MinimalCheckSuite {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckSuiteId, MinimalCheckSuite};
+
+    const JSON: &str = r#"
+    {
+        "id": 5
+    }
+    "#;
+
+    #[test]
+    fn trait_deserialize() {
+        let check_suite: MinimalCheckSuite = serde_json::from_str(JSON).unwrap();
+
+        assert_eq!(5, check_suite.id().get());
+    }
+
+    #[test]
+    fn trait_display() {
+        let minimal_check_suite = MinimalCheckSuite {
+            id: CheckSuiteId::new(5),
+        };
+
+        assert_eq!("5", minimal_check_suite.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<MinimalCheckSuite>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<MinimalCheckSuite>();
+    }
+}

--- a/integrations/github/src/resource/check_suite/mod.rs
+++ b/integrations/github/src/resource/check_suite/mod.rs
@@ -9,6 +9,10 @@ use crate::resource::{
     App, CheckRunConclusion, CheckRunStatus, GitRef, GitSha, NodeId, PullRequest,
 };
 
+pub use self::minimal::MinimalCheckSuite;
+
+mod minimal;
+
 id!(
     /// Check suite id
     ///
@@ -27,7 +31,9 @@ id!(
 /// Read more: https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct CheckSuite {
-    id: CheckSuiteId,
+    #[serde(flatten)]
+    minimal: MinimalCheckSuite,
+
     node_id: NodeId,
     head_branch: GitRef,
     head_sha: GitSha,
@@ -46,7 +52,7 @@ impl CheckSuite {
     /// Returns the check suite's id.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn id(&self) -> CheckSuiteId {
-        self.id
+        self.minimal.id()
     }
 
     /// Returns the check suite's node id.
@@ -124,7 +130,7 @@ impl CheckSuite {
 
 impl Display for CheckSuite {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id)
+        write!(f, "{}", self.id())
     }
 }
 
@@ -135,7 +141,7 @@ mod tests {
     #[test]
     fn trait_deserialize() {
         let suite: CheckSuite = serde_json::from_str(include_str!(
-            "../../tests/fixtures/resource/check_suite.json"
+            "../../../tests/fixtures/resource/check_suite.json"
         ))
         .unwrap();
 
@@ -145,7 +151,7 @@ mod tests {
     #[test]
     fn trait_display() {
         let suite: CheckSuite = serde_json::from_str(include_str!(
-            "../../tests/fixtures/resource/check_suite.json"
+            "../../../tests/fixtures/resource/check_suite.json"
         ))
         .unwrap();
 

--- a/integrations/github/src/resource/mod.rs
+++ b/integrations/github/src/resource/mod.rs
@@ -6,6 +6,8 @@
 //!
 //! [automatons]: https://github.com/devxbots/automatons
 
+use serde::{Deserialize, Serialize};
+
 use crate::name;
 
 pub use self::account::{Account, AccountId, AccountType, Login};
@@ -14,7 +16,7 @@ pub use self::check_run::{
     CheckRun, CheckRunConclusion, CheckRunId, CheckRunName, CheckRunOutput, CheckRunOutputSummary,
     CheckRunOutputTitle, CheckRunStatus,
 };
-pub use self::check_suite::CheckSuite;
+pub use self::check_suite::{CheckSuite, CheckSuiteId, MinimalCheckSuite};
 pub use self::git::{GitRef, GitSha};
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
@@ -44,6 +46,21 @@ name!(
     /// resource in [GitHub's GraphQL API](https://docs.github.com/en/graphql).
     NodeId
 );
+
+/// Field with multiple representations
+///
+/// GitHub truncates data types in some API responses and webhook events to reduce the payload size.
+/// The `Field` enum represents fields in responses that have different representations based on
+/// context.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Field<Minimal, Full> {
+    /// Minimal representation of the field
+    Minimal(Minimal),
+
+    /// Full representation of the field
+    Full(Full),
+}
 
 #[cfg(test)]
 mod tests {

--- a/integrations/github/src/task/list_check_runs.rs
+++ b/integrations/github/src/task/list_check_runs.rs
@@ -1,0 +1,185 @@
+use anyhow::Context;
+use async_trait::async_trait;
+use reqwest::Method;
+
+use automatons::{Error, State, Task, Transition};
+
+use crate::client::GitHubClient;
+use crate::resource::{CheckRun, CheckSuiteId, Login, RepositoryName};
+
+/// List the check runs for a check suite
+///
+/// Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read`
+/// permission on a private repository or pull access to a public repository to get check runs.
+/// OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private
+/// repository.
+///
+/// # Parameters
+///
+/// The task requires the following parameters in the state:
+///
+/// - `Owner`: The account owner of the repository
+/// - `RepositoryName`: The name of the repository
+/// - `CheckSuiteId`: The id of the check suite
+///
+/// https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct ListCheckRunsForCheckSuite;
+
+#[async_trait]
+impl Task for ListCheckRunsForCheckSuite {
+    async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
+        let mut task = TaskImpl::from_state(state)?;
+
+        let check_runs = task.execute(state).await?;
+        state.insert(check_runs);
+
+        Ok(Transition::Next)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TaskImpl<'a> {
+    github_client: &'a GitHubClient,
+    owner: &'a Login,
+    repository: &'a RepositoryName,
+}
+
+impl<'a> TaskImpl<'a> {
+    fn from_state(state: &'a State) -> Result<TaskImpl<'a>, Error> {
+        let github_client = state
+            .get()
+            .context("failed to get GitHub client from state")?;
+        let owner = state
+            .get::<Login>()
+            .context("failed to get owner from state")?;
+        let repository = state
+            .get::<RepositoryName>()
+            .context("failed to get repository name from state")?;
+
+        Ok(Self {
+            github_client,
+            owner,
+            repository,
+        })
+    }
+
+    async fn execute(&mut self, state: &State) -> Result<Vec<CheckRun>, Error> {
+        let check_suite_id = state
+            .get::<CheckSuiteId>()
+            .context("failed to get check suite id from state")?;
+
+        let url = format!(
+            "/repos/{}/{}/check-suites/{}/check-runs",
+            self.owner.get(),
+            self.repository.get(),
+            check_suite_id
+        );
+
+        let check_runs = self
+            .github_client
+            .paginate(Method::GET, &url, "check_runs")
+            .await
+            .context("failed to query check runs")?;
+
+        Ok(check_runs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use automatons::{State, Task, Transition};
+
+    use crate::resource::{CheckRun, CheckSuiteId, Login, RepositoryName};
+    use crate::testing::check_run::mock_list_check_runs_for_check_suite;
+    use crate::testing::client::github_client;
+    use crate::testing::token::mock_installation_access_tokens;
+
+    use super::ListCheckRunsForCheckSuite;
+
+    #[tokio::test]
+    async fn task_returns_error_when_github_client_is_missing() {
+        let mut state = State::new();
+
+        state.insert(Login::new("github"));
+        state.insert(RepositoryName::new("hello-world"));
+        state.insert(CheckSuiteId::new(5));
+
+        let mut task = ListCheckRunsForCheckSuite;
+        let transition = task.execute(&mut state).await;
+
+        assert!(transition.is_err());
+    }
+
+    #[tokio::test]
+    async fn task_returns_error_when_login_is_missing() {
+        let mut state = State::new();
+
+        state.insert(github_client());
+        state.insert(RepositoryName::new("hello-world"));
+        state.insert(CheckSuiteId::new(5));
+
+        let mut task = ListCheckRunsForCheckSuite;
+        let transition = task.execute(&mut state).await;
+
+        assert!(transition.is_err());
+    }
+    #[tokio::test]
+    async fn task_returns_error_when_repository_name_is_missing() {
+        let mut state = State::new();
+
+        state.insert(github_client());
+        state.insert(Login::new("github"));
+        state.insert(CheckSuiteId::new(5));
+
+        let mut task = ListCheckRunsForCheckSuite;
+        let transition = task.execute(&mut state).await;
+
+        assert!(transition.is_err());
+    }
+
+    #[tokio::test]
+    async fn task_returns_error_when_check_suite_id_is_missing() {
+        let mut state = State::new();
+
+        state.insert(github_client());
+        state.insert(Login::new("github"));
+        state.insert(RepositoryName::new("hello-world"));
+
+        let mut task = ListCheckRunsForCheckSuite;
+        let transition = task.execute(&mut state).await;
+
+        assert!(transition.is_err());
+    }
+
+    #[tokio::test]
+    async fn task_puts_check_runs_into_state() {
+        let _token_mock = mock_installation_access_tokens();
+        let _content_mock = mock_list_check_runs_for_check_suite();
+
+        let mut state = State::new();
+
+        state.insert(github_client());
+        state.insert(Login::new("github"));
+        state.insert(RepositoryName::new("hello-world"));
+        state.insert(CheckSuiteId::new(5));
+
+        let mut task = ListCheckRunsForCheckSuite;
+        let transition = task.execute(&mut state).await.unwrap();
+
+        assert!(matches!(transition, Transition::Next));
+        assert!(state.get::<Vec<CheckRun>>().is_some());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ListCheckRunsForCheckSuite>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ListCheckRunsForCheckSuite>();
+    }
+}

--- a/integrations/github/src/task/mod.rs
+++ b/integrations/github/src/task/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! The GitHub integration implements tasks that can be used to create automatons.
 
+pub use self::list_check_runs::ListCheckRunsForCheckSuite;
 pub use self::list_check_suites::ListCheckSuites;
 
+mod list_check_runs;
 mod list_check_suites;

--- a/integrations/github/src/testing/check_run.rs
+++ b/integrations/github/src/testing/check_run.rs
@@ -1,0 +1,102 @@
+use mockito::{mock, Mock};
+
+pub fn mock_list_check_runs_for_check_suite() -> Mock {
+    mock("GET", "/repos/github/hello-world/check-suites/5/check-runs").with_status(200).with_body(r#"
+        {
+          "total_count": 1,
+          "check_runs": [
+            {
+              "id": 4,
+              "head_sha": "ce587453ced02b1526dfb4cb910479d431683101",
+              "node_id": "MDg6Q2hlY2tSdW40",
+              "external_id": "",
+              "url": "https://api.github.com/repos/github/hello-world/check-runs/4",
+              "html_url": "https://github.com/github/hello-world/runs/4",
+              "details_url": "https://example.com",
+              "status": "completed",
+              "conclusion": "neutral",
+              "started_at": "2018-05-04T01:14:52Z",
+              "completed_at": "2018-05-04T01:14:52Z",
+              "output": {
+                "title": "Mighty Readme report",
+                "summary": "There are 0 failures, 2 warnings, and 1 notice.",
+                "text": "You may have some misspelled words on lines 2 and 4. You also may want to add a section in your README about how to install your app.",
+                "annotations_count": 2,
+                "annotations_url": "https://api.github.com/repos/github/hello-world/check-runs/4/annotations"
+              },
+              "name": "mighty_readme",
+              "check_suite": {
+                "id": 5
+              },
+              "app": {
+                "id": 1,
+                "slug": "octoapp",
+                "node_id": "MDExOkludGVncmF0aW9uMQ==",
+                "owner": {
+                  "login": "github",
+                  "id": 1,
+                  "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                  "url": "https://api.github.com/orgs/github",
+                  "repos_url": "https://api.github.com/orgs/github/repos",
+                  "events_url": "https://api.github.com/orgs/github/events",
+                  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                  "gravatar_id": "",
+                  "html_url": "https://github.com/octocat",
+                  "followers_url": "https://api.github.com/users/octocat/followers",
+                  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                  "organizations_url": "https://api.github.com/users/octocat/orgs",
+                  "received_events_url": "https://api.github.com/users/octocat/received_events",
+                  "type": "User",
+                  "site_admin": true
+                },
+                "name": "Octocat App",
+                "description": "",
+                "external_url": "https://example.com",
+                "html_url": "https://github.com/apps/octoapp",
+                "created_at": "2017-07-08T16:18:44-04:00",
+                "updated_at": "2017-07-08T16:18:44-04:00",
+                "permissions": {
+                  "metadata": "read",
+                  "contents": "read",
+                  "issues": "write",
+                  "single_file": "write"
+                },
+                "events": [
+                  "push",
+                  "pull_request"
+                ]
+              },
+              "pull_requests": [
+                {
+                  "url": "https://api.github.com/repos/github/hello-world/pulls/1",
+                  "id": 1934,
+                  "number": 3956,
+                  "head": {
+                    "ref": "say-hello",
+                    "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
+                    "repo": {
+                      "id": 526,
+                      "url": "https://api.github.com/repos/github/hello-world",
+                      "name": "hello-world"
+                    }
+                  },
+                  "base": {
+                    "ref": "master",
+                    "sha": "e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f",
+                    "repo": {
+                      "id": 526,
+                      "url": "https://api.github.com/repos/github/hello-world",
+                      "name": "hello-world"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+    "#
+    ).create()
+}

--- a/integrations/github/src/testing/mod.rs
+++ b/integrations/github/src/testing/mod.rs
@@ -1,3 +1,4 @@
+pub mod check_run;
 pub mod check_suite;
 pub mod client;
 pub mod token;


### PR DESCRIPTION
A new task has been created that lists the check runs of a check suite. The task uses pagination to fetch all check runs from GitHub, and then adds them to the shared state.