### PR TITLE
Bump crates from 0.1.0 to 0.2.0

### DIFF
--- a/automatons/Cargo.toml
+++ b/automatons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automatons"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 description = "Automation framework for software developers"

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automatons-github"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 description = "GitHub integration for the automatons framework"
@@ -21,7 +21,7 @@ keywords = [
 [dependencies]
 anyhow = { version = "1" }
 async-trait = "0.1"
-automatons = { path = "../../automatons", version = "0.1" }
+automatons = { path = "../../automatons", version = "0.2" }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.24"
 jsonwebtoken = { version = "8" }


### PR DESCRIPTION
A new version of both crates is released in anticipation of significant changes to their core logic. This is as far as we are going to push the current task design, so releasing a "final" version seems appropriate.