### PR TITLE
Redesign internal state machine in automatons

### DIFF
--- a/automatons/tests/hello-world.rs
+++ b/automatons/tests/hello-world.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 
-use automatons::{Automaton, Error, State, Task, Tasks, Transition};
+use automatons::{Automaton, Error, State, Task, Transition};
 
 #[tokio::test]
 async fn test() -> Result<(), Error> {
@@ -28,8 +28,8 @@ struct Hello;
 struct World;
 
 impl Automaton for HelloWorld {
-    fn tasks(&self) -> Tasks {
-        vec![Box::new(Hello), Box::new(World)]
+    fn initial_task(&self) -> Box<dyn Task> {
+        Box::new(Hello)
     }
 }
 
@@ -37,7 +37,7 @@ impl Automaton for HelloWorld {
 impl Task for Hello {
     async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
         state.insert(Message(String::from("Hello")));
-        Ok(Transition::Next)
+        Ok(Transition::Next(Box::new(World)))
     }
 }
 
@@ -50,6 +50,6 @@ impl Task for World {
 
         message.0.push_str(", World!");
 
-        Ok(Transition::Next)
+        Ok(Transition::Complete)
     }
 }

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -21,7 +21,7 @@ keywords = [
 [dependencies]
 anyhow = { version = "1" }
 async-trait = "0.1"
-automatons = { path = "../../automatons", version = "0.2" }
+automatons = { version = "0.2" }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.24"
 jsonwebtoken = { version = "8" }


### PR DESCRIPTION
After some consideration, the decision has been made to refactor the state machine in the `automatons` crate.

The previous design was optimized for loose coupling of tasks, but it came with considerable downsides. First, automatons were only able to execute a sequential series of tasks. This works for simple automations, but is not flexible enough to implement more complex workflows. And second, the state was abused as a means to pass data between tasks. The design didn't leverage the strength of the Rust compiler to ensure that each task had the data that it needed at the time that it was run.

We are taking a step back and going back to an earlier design that was used in `devxbots/octox` [^1]. Fundamentally, the GitHub integration will only implement abstractions around GitHub's API. Implementing the state machine with its states will be the responsibility of the individual bots. The downside of this approach is that states are merely thin wrappers around the GitHub actions, but it does give bots a lot more flexibility in how to implement their states.