### PR TITLE
Remove Task trait from GitHub tasks

### DIFF
--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -21,7 +21,7 @@ keywords = [
 [dependencies]
 anyhow = { version = "1" }
 async-trait = "0.1"
-automatons = { version = "0.2" }
+automatons = { path = "../../automatons", version = "0.2" }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.24"
 jsonwebtoken = { version = "8" }

--- a/integrations/github/src/task/list_check_runs_for_git_sha.rs
+++ b/integrations/github/src/task/list_check_runs_for_git_sha.rs
@@ -1,9 +1,8 @@
 use anyhow::Context;
-use async_trait::async_trait;
-use futures::future::try_join_all;
 use reqwest::Method;
 
-use automatons::{Error, State, Task, Transition};
+use automatons::Error;
+use futures::future::try_join_all;
 
 use crate::client::GitHubClient;
 use crate::resource::{CheckRun, CheckSuite, GitSha, Login, RepositoryName};
@@ -14,64 +13,42 @@ use crate::resource::{CheckRun, CheckSuite, GitSha, Login, RepositoryName};
 /// private repository or pull access to a public repository to get check runs. OAuth Apps and
 /// authenticated users must have the `repo` scope to get check runs in a private repository.
 ///
-/// # Parameters
-///
-/// The task requires the following parameters in the state:
-///
-/// - `Owner`: The account owner of the repository
-/// - `RepositoryName`: The name of the repository
-/// - `GitSha`: The SHA of the Git commit
-///
 /// https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct ListCheckRunsForGitSha;
-
-#[async_trait]
-impl Task for ListCheckRunsForGitSha {
-    async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
-        let mut task = TaskImpl::from_state(state)?;
-
-        let check_suites = task.list_check_suites().await?;
-        let check_runs = task.list_check_runs_for_check_suites(&check_suites).await?;
-
-        state.insert(check_runs);
-
-        Ok(Transition::Next)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct TaskImpl<'a> {
+#[derive(Copy, Clone, Debug)]
+pub struct ListCheckRunsForGitSha<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
     git_sha: &'a GitSha,
 }
 
-impl<'a> TaskImpl<'a> {
-    fn from_state(state: &'a State) -> Result<TaskImpl<'a>, Error> {
-        let github_client = state
-            .get()
-            .context("failed to get GitHub client from state")?;
-        let owner = state
-            .get::<Login>()
-            .context("failed to get owner from state")?;
-        let repository = state
-            .get::<RepositoryName>()
-            .context("failed to get repository name from state")?;
-        let git_sha = state
-            .get::<GitSha>()
-            .context("failed to get Git SHA from state")?;
-
-        Ok(Self {
+impl<'a> ListCheckRunsForGitSha<'a> {
+    /// Initializes the task
+    pub fn new(
+        github_client: &'a GitHubClient,
+        owner: &'a Login,
+        repository: &'a RepositoryName,
+        git_sha: &'a GitSha,
+    ) -> Self {
+        Self {
             github_client,
             owner,
             repository,
             git_sha,
-        })
+        }
     }
 
-    async fn list_check_suites(&mut self) -> Result<Vec<CheckSuite>, Error> {
+    /// List the check runs for a Git reference
+    ///
+    /// Lists check runs for a commit ref.
+    pub async fn execute(&self) -> Result<Vec<CheckRun>, Error> {
+        let check_suites = self.list_check_suites().await?;
+        let check_runs = self.list_check_runs_for_check_suites(&check_suites).await?;
+
+        Ok(check_runs)
+    }
+
+    async fn list_check_suites(&self) -> Result<Vec<CheckSuite>, Error> {
         let url = format!(
             "/repos/{}/{}/commits/{}/check-suites",
             self.owner.get(),
@@ -128,9 +105,7 @@ impl<'a> TaskImpl<'a> {
 
 #[cfg(test)]
 mod tests {
-    use automatons::{State, Task, Transition};
-
-    use crate::resource::{CheckRun, GitSha, Login, RepositoryName};
+    use crate::resource::{GitSha, Login, RepositoryName};
     use crate::testing::check_run::mock_list_check_runs_for_check_suite;
     use crate::testing::check_suite::mock_list_check_suites;
     use crate::testing::client::github_client;
@@ -139,78 +114,21 @@ mod tests {
     use super::ListCheckRunsForGitSha;
 
     #[tokio::test]
-    async fn task_returns_error_when_github_client_is_missing() {
-        let mut state = State::new();
-
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(GitSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"));
-
-        let mut task = ListCheckRunsForGitSha;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_returns_error_when_login_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(GitSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"));
-
-        let mut task = ListCheckRunsForGitSha;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-    #[tokio::test]
-    async fn task_returns_error_when_repository_name_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(GitSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"));
-
-        let mut task = ListCheckRunsForGitSha;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_returns_error_when_git_sha_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-
-        let mut task = ListCheckRunsForGitSha;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_puts_check_runs_into_state() {
+    async fn task_returns_check_runs() {
         let _token_mock = mock_installation_access_tokens();
         let _check_suite_mock = mock_list_check_suites();
         let _check_runs_mock = mock_list_check_runs_for_check_suite();
 
-        let mut state = State::new();
+        let github_client = github_client();
+        let login = Login::new("github");
+        let repository = RepositoryName::new("hello-world");
+        let git_sha = GitSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3");
 
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(GitSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"));
+        let task = ListCheckRunsForGitSha::new(&github_client, &login, &repository, &git_sha);
 
-        let mut task = ListCheckRunsForGitSha;
-        let transition = task.execute(&mut state).await.unwrap();
+        let check_runs = task.execute().await.unwrap();
 
-        assert!(matches!(transition, Transition::Next));
-        assert!(state.get::<Vec<CheckRun>>().is_some());
+        assert_eq!(1, check_runs.len());
     }
 
     #[test]

--- a/integrations/github/src/task/update_check_run.rs
+++ b/integrations/github/src/task/update_check_run.rs
@@ -1,10 +1,9 @@
 use anyhow::Context;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use url::Url;
 
-use automatons::{Error, State, Task, Transition};
+use automatons::Error;
 
 use crate::client::GitHubClient;
 use crate::resource::{
@@ -17,17 +16,14 @@ use crate::resource::{
 /// Updates a check run for a specific commit in a repository. The GitHub App must have the
 /// `checks:write` permission to edit check runs.
 ///
-/// # Parameters
-///
-/// The task requires the following parameters in the state:
-///
-/// - `Owner`: The account owner of the repository
-/// - `RepositoryName`: The name of the repository
-/// - `UpdateCheckRunInput`: The input for the task
-///
 /// https://docs.github.com/en/rest/checks/runs#update-a-check-run
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct UpdateCheckRun;
+#[derive(Copy, Clone, Debug)]
+pub struct UpdateCheckRun<'a> {
+    github_client: &'a GitHubClient,
+    owner: &'a Login,
+    repository: &'a RepositoryName,
+    check_run_input: &'a UpdateCheckRunInput,
+}
 
 /// Input for update check run task
 ///
@@ -78,50 +74,26 @@ pub struct UpdateCheckRunInput {
     pub output: Option<CheckRunOutput>,
 }
 
-#[async_trait]
-impl Task for UpdateCheckRun {
-    async fn execute(&mut self, state: &mut State) -> Result<Transition, Error> {
-        let task = TaskImpl::from_state(state)?;
-
-        let check_run = task.execute().await?;
-        state.insert(check_run);
-
-        Ok(Transition::Next)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct TaskImpl<'a> {
-    github_client: &'a GitHubClient,
-    owner: &'a Login,
-    repository: &'a RepositoryName,
-    check_run_input: &'a UpdateCheckRunInput,
-}
-
-impl<'a> TaskImpl<'a> {
-    fn from_state(state: &'a State) -> Result<TaskImpl<'a>, Error> {
-        let github_client = state
-            .get()
-            .context("failed to get GitHub client from state")?;
-        let owner = state
-            .get::<Login>()
-            .context("failed to get owner from state")?;
-        let repository = state
-            .get::<RepositoryName>()
-            .context("failed to get repository name from state")?;
-        let check_run_input = state
-            .get::<UpdateCheckRunInput>()
-            .context("failed to get input for update check run task from state")?;
-
-        Ok(Self {
+impl<'a> UpdateCheckRun<'a> {
+    /// Initializes the task
+    pub fn new(
+        github_client: &'a GitHubClient,
+        owner: &'a Login,
+        repository: &'a RepositoryName,
+        check_run_input: &'a UpdateCheckRunInput,
+    ) -> Self {
+        Self {
             github_client,
             owner,
             repository,
             check_run_input,
-        })
+        }
     }
 
-    async fn execute(&self) -> Result<CheckRun, Error> {
+    /// Update a check run
+    ///
+    /// Updates a check run for a specific commit in a repository.
+    pub async fn execute(&self) -> Result<CheckRun, Error> {
         let url = format!(
             "/repos/{}/{}/check-runs/{}",
             self.owner.get(),
@@ -141,9 +113,7 @@ impl<'a> TaskImpl<'a> {
 
 #[cfg(test)]
 mod tests {
-    use automatons::{State, Task, Transition};
-
-    use crate::resource::{CheckRun, CheckRunId, CheckRunName, Login, RepositoryName};
+    use crate::resource::{CheckRunId, CheckRunName, Login, RepositoryName};
     use crate::testing::check_run::mock_update_check_run;
     use crate::testing::client::github_client;
     use crate::testing::token::mock_installation_access_tokens;
@@ -165,77 +135,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_returns_error_when_github_client_is_missing() {
-        let mut state = State::new();
-
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(input());
-
-        let mut task = UpdateCheckRun;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_returns_error_when_login_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(input());
-
-        let mut task = UpdateCheckRun;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-    #[tokio::test]
-    async fn task_returns_error_when_repository_name_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(input());
-
-        let mut task = UpdateCheckRun;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_returns_error_when_input_is_missing() {
-        let mut state = State::new();
-
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-
-        let mut task = UpdateCheckRun;
-        let transition = task.execute(&mut state).await;
-
-        assert!(transition.is_err());
-    }
-
-    #[tokio::test]
-    async fn task_puts_check_run_into_state() {
+    async fn task_returns_updated_check_run() {
         let _token_mock = mock_installation_access_tokens();
         let _content_mock = mock_update_check_run();
 
-        let mut state = State::new();
+        let github_client = github_client();
+        let login = Login::new("github");
+        let repository = RepositoryName::new("hello-world");
+        let input = input();
 
-        state.insert(github_client());
-        state.insert(Login::new("github"));
-        state.insert(RepositoryName::new("hello-world"));
-        state.insert(input());
+        let task = UpdateCheckRun::new(&github_client, &login, &repository, &input);
 
-        let mut task = UpdateCheckRun;
-        let transition = task.execute(&mut state).await.unwrap();
+        let check_run = task.execute().await.unwrap();
 
-        assert!(matches!(transition, Transition::Next));
-        assert!(state.get::<CheckRun>().is_some());
+        assert_eq!("mighty_readme", check_run.name().get());
     }
 
     #[test]


### PR DESCRIPTION
The tasks in the GitHub integration do no longer implement the `Task` trait from the `automatons` crate. They simply interact with GitHub's API, without knowledge of an automation's state machine.