### PR TITLE
Create task to get a file from GitHub

### DIFF
--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -37,6 +37,8 @@ serde_json = { version = "1" }
 thiserror = { version = "1" }
 tracing = { version = "0.1", optional = true }
 url = { version = "2", features = ["serde"] }
+base64 = "0.13.0"
+serde_bytes = "0.11.7"
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/integrations/github/src/resource/file.rs
+++ b/integrations/github/src/resource/file.rs
@@ -1,0 +1,174 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::resource::GitSha;
+
+/// File in a repository
+///
+/// Git repositories store files and directories. They can be queried using GitHub's [contents] API.
+/// The API returns a file object with a set of metadata, e.g. the file size, name, and path. The
+/// file's content is embedded in the response up to a certain size, and encoded using the file's
+/// encoding.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct File {
+    name: String,
+    path: String,
+    #[serde(with = "serde_bytes")]
+    content: Vec<u8>,
+    sha: GitSha,
+    url: Url,
+    git_url: Url,
+    html_url: Url,
+    download_url: Url,
+}
+
+impl File {
+    /// Initializes a new file
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        name: String,
+        path: String,
+        content: Vec<u8>,
+        sha: GitSha,
+        url: Url,
+        git_url: Url,
+        html_url: Url,
+        download_url: Url,
+    ) -> Self {
+        Self {
+            name,
+            path,
+            content,
+            sha,
+            url,
+            git_url,
+            html_url,
+            download_url,
+        }
+    }
+
+    /// Returns the file name.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    /// Returns the path of the file.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn path(&self) -> &String {
+        &self.path
+    }
+
+    /// Returns the file contents.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn content(&self) -> &[u8] {
+        &self.content
+    }
+
+    /// Returns the SHA of the Git commit to which the file belongs.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn sha(&self) -> &GitSha {
+        &self.sha
+    }
+
+    /// Returns the API endpoint to query the file.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Returns the API endpoint to query the file's Git commit.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn git_url(&self) -> &Url {
+        &self.git_url
+    }
+
+    /// Returns the URL to the account.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn html_url(&self) -> &Url {
+        &self.html_url
+    }
+
+    /// Returns a temporary URL to download the file.
+    ///
+    /// Download URLs expire and are meant to be used just once. To ensure the download URL does not
+    /// expire, please use the contents API to obtain a fresh download URL for each download.
+    #[cfg_attr(feature = "tracing", tracing::instrument)]
+    pub fn download_url(&self) -> &Url {
+        &self.download_url
+    }
+}
+
+impl Display for File {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::File;
+
+    #[rustfmt::skip]
+    fn file() -> File {
+        File {
+            name: "README.md".into(),
+            path: "README.md".into(),
+            content: "ZW5jb2RlZCBjb250ZW50IC4uLg==".into(),
+            sha: "3d21ec53a331a6f037a91c368710b99387d012c1".into(),
+            url: Url::parse("https://api.github.com/repos/octokit/octokit.rb/contents/README.md").unwrap(),
+            git_url: Url::parse("https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1").unwrap(),
+            html_url: Url::parse("https://github.com/octokit/octokit.rb/blob/master/README.md").unwrap(),
+            download_url: Url::parse("https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md").unwrap(),
+        }
+    }
+
+    #[test]
+    fn trait_deserialize() {
+        let json = r#"
+        {
+          "type": "file",
+          "encoding": "base64",
+          "size": 5362,
+          "name": "README.md",
+          "path": "README.md",
+          "content": "ZW5jb2RlZCBjb250ZW50IC4uLg==",
+          "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+          "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+          "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+          "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+          "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+          "_links": {
+            "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+            "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+            "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+          }
+        }
+        "#;
+
+        let file: File = serde_json::from_str(json).unwrap();
+
+        assert_eq!("README.md", file.name());
+    }
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("README.md", file().to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<File>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<File>();
+    }
+}

--- a/integrations/github/src/resource/mod.rs
+++ b/integrations/github/src/resource/mod.rs
@@ -17,6 +17,7 @@ pub use self::check_run::{
     CheckRunOutputTitle, CheckRunStatus,
 };
 pub use self::check_suite::{CheckSuite, CheckSuiteId, MinimalCheckSuite};
+pub use self::file::File;
 pub use self::git::{GitRef, GitSha};
 pub use self::installation::{Installation, InstallationId};
 pub use self::license::{License, LicenseKey, LicenseName, SpdxId};
@@ -31,6 +32,7 @@ mod account;
 mod app;
 mod check_run;
 mod check_suite;
+mod file;
 mod git;
 mod installation;
 mod license;

--- a/integrations/github/src/task/get_file.rs
+++ b/integrations/github/src/task/get_file.rs
@@ -1,0 +1,263 @@
+use anyhow::Context;
+use base64::decode;
+use serde::Deserialize;
+use serde_json::Value;
+use url::Url;
+
+use automatons::Error;
+
+use crate::client::GitHubClient;
+use crate::resource::{File, Login, RepositoryName};
+
+/// Gets a file in a repository
+///
+/// Gets the contents of a file in a repository.
+///
+/// # Size limits
+///
+/// The task only supports files that are smaller than 1MB.
+///
+/// https://docs.github.com/en/rest/repos/contents#get-repository-content
+#[derive(Copy, Clone, Debug)]
+pub struct GetFile<'a> {
+    github_client: &'a GitHubClient,
+    owner: &'a Login,
+    repository: &'a RepositoryName,
+    path: &'a str,
+}
+
+impl<'a> GetFile<'a> {
+    /// Initializes the task
+    pub fn new(
+        github_client: &'a GitHubClient,
+        owner: &'a Login,
+        repository: &'a RepositoryName,
+        path: &'a str,
+    ) -> Self {
+        Self {
+            github_client,
+            owner,
+            repository,
+            path,
+        }
+    }
+
+    /// Gets a file in a repository
+    ///
+    /// Gets the contents of a file in a repository.
+    pub async fn execute(&self) -> Result<File, Error> {
+        let url = format!(
+            "/repos/{}/{}/contents/{}",
+            self.owner.get(),
+            self.repository.get(),
+            self.path
+        );
+
+        let payload = self.github_client.get(&url).await?;
+
+        let body = match payload {
+            GetFileResponse::Success(body) => body,
+            GetFileResponse::Error(_) => return Err(Error::NotFound(url)),
+        };
+
+        if body.is_array() {
+            Err(Error::Serialization(
+                "failed to handle unsupported directory payload".into(),
+            ))
+        } else {
+            let payload: GetFilePayload = serde_json::from_value(body).map_err(|_| {
+                Error::Serialization(
+                    "failed to deserialize payload from GitHub's contents API".into(),
+                )
+            })?;
+
+            File::try_from(payload)
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(untagged)]
+enum GetFileResponse {
+    Error(GetFileErrorPayload),
+    Success(Value),
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+struct GetFileErrorPayload {
+    message: String,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum GetFilePayload {
+    Directory,
+    File(Box<FilePayload>),
+    Submodule,
+    Symlink,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+struct FilePayload {
+    encoding: FileEncoding,
+    size: u64,
+    name: String,
+    path: String,
+    content: String,
+    sha: String,
+    url: Url,
+    git_url: Url,
+    html_url: Url,
+    download_url: Url,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FileEncoding {
+    Base64,
+}
+
+impl TryFrom<GetFilePayload> for File {
+    type Error = Error;
+
+    fn try_from(value: GetFilePayload) -> Result<Self, Self::Error> {
+        let payload = match value {
+            GetFilePayload::Directory => Err(Error::Serialization(
+                "failed to handle unsupported directory payload".into(),
+            )),
+            GetFilePayload::File(payload) => Ok(payload),
+            GetFilePayload::Submodule => Err(Error::Serialization(
+                "failed to handle unsupported submodule payload".into(),
+            )),
+            GetFilePayload::Symlink => Err(Error::Serialization(
+                "failed to handle unsupported symlink payload".into(),
+            )),
+        }?;
+
+        let sanitized_content = &payload.content.replace('\n', "");
+        let content =
+            decode(sanitized_content).context("failed to decode Base64 encoded file content")?;
+
+        Ok(File::new(
+            payload.name,
+            payload.path,
+            content,
+            payload.sha.into(),
+            payload.url,
+            payload.git_url,
+            payload.html_url,
+            payload.download_url,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockito::mock;
+
+    use automatons::Error;
+
+    use crate::resource::{Login, RepositoryName};
+    use crate::testing::client::github_client;
+    use crate::testing::contents::{
+        mock_get_contents_directory, mock_get_contents_file, mock_get_contents_submodule,
+        mock_get_contents_symlink,
+    };
+    use crate::testing::token::mock_installation_access_tokens;
+
+    use super::GetFile;
+
+    #[tokio::test]
+    async fn get_file_with_file() {
+        let _token_mock = mock_installation_access_tokens();
+        let _content_mock = mock_get_contents_file();
+
+        let github_client = github_client();
+        let login = Login::new("octokit");
+        let repository = RepositoryName::new("octokit.rb");
+        let path = "README.md";
+
+        let task = GetFile::new(&github_client, &login, &repository, path);
+
+        let file = task.execute().await.unwrap();
+
+        assert_eq!("README.md", file.name());
+    }
+
+    #[tokio::test]
+    async fn get_file_with_directory() {
+        let _token_mock = mock_installation_access_tokens();
+        let _content_mock = mock_get_contents_directory();
+
+        let github_client = github_client();
+        let login = Login::new("octokit");
+        let repository = RepositoryName::new("octokit.rb");
+        let path = "lib/octokit";
+
+        let task = GetFile::new(&github_client, &login, &repository, path);
+
+        let error = task.execute().await.unwrap_err();
+        println!("{:?}", error);
+
+        assert!(matches!(error, Error::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn get_file_with_symlink() {
+        let _token_mock = mock_installation_access_tokens();
+        let _content_mock = mock_get_contents_symlink();
+
+        let github_client = github_client();
+        let login = Login::new("octokit");
+        let repository = RepositoryName::new("octokit.rb");
+        let path = "bin/some-symlink";
+
+        let task = GetFile::new(&github_client, &login, &repository, path);
+
+        let error = task.execute().await.unwrap_err();
+
+        assert!(matches!(error, Error::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn get_file_with_submodule() {
+        let _token_mock = mock_installation_access_tokens();
+        let _content_mock = mock_get_contents_submodule();
+
+        let github_client = github_client();
+        let login = Login::new("jquery");
+        let repository = RepositoryName::new("jquery");
+        let path = "test/qunit";
+
+        let task = GetFile::new(&github_client, &login, &repository, path);
+
+        let error = task.execute().await.unwrap_err();
+
+        assert!(matches!(error, Error::Serialization(_)));
+    }
+
+    #[tokio::test]
+    async fn get_file_not_found() {
+        let _token_mock = mock_installation_access_tokens();
+
+        let _content_mock = mock("GET", "/repos/devxbots/automatons/contents/README.md")
+            .with_status(404)
+            .with_body(r#"
+                {
+                    "message": "Not Found",
+                    "documentation_url": "https://docs.github.com/rest/reference/repos#get-repository-content"
+                }
+            "#).create();
+
+        let github_client = github_client();
+        let login = Login::new("devxbots");
+        let repository = RepositoryName::new("automatons");
+        let path = "README.md";
+
+        let task = GetFile::new(&github_client, &login, &repository, path);
+
+        let error = task.execute().await.unwrap_err();
+
+        assert!(matches!(error, Error::NotFound(_)));
+    }
+}

--- a/integrations/github/src/task/mod.rs
+++ b/integrations/github/src/task/mod.rs
@@ -3,12 +3,14 @@
 //! The GitHub integration implements tasks that can be used to create automatons.
 
 pub use self::create_check_run::{CreateCheckRun, CreateCheckRunInput};
+pub use self::get_file::GetFile;
 pub use self::list_check_runs_for_check_suite::ListCheckRunsForCheckSuite;
 pub use self::list_check_runs_for_git_sha::ListCheckRunsForGitSha;
 pub use self::list_check_suites::ListCheckSuites;
 pub use self::update_check_run::{UpdateCheckRun, UpdateCheckRunInput};
 
 mod create_check_run;
+mod get_file;
 mod list_check_runs_for_check_suite;
 mod list_check_runs_for_git_sha;
 mod list_check_suites;

--- a/integrations/github/src/testing/contents.rs
+++ b/integrations/github/src/testing/contents.rs
@@ -1,0 +1,123 @@
+use mockito::{mock, Mock};
+
+pub fn mock_get_contents_file() -> Mock {
+    mock("GET", "/repos/octokit/octokit.rb/contents/README.md")
+        .with_status(200)
+        .with_body(r#"
+            {
+              "type": "file",
+              "encoding": "base64",
+              "size": 5362,
+              "name": "README.md",
+              "path": "README.md",
+              "content": "ZW5jb2RlZCBjb250ZW50IC4uLg==",
+              "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+              "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+              "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+              "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+              "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+              "_links": {
+                "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+                "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+                "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+              }
+            }
+        "#
+        )
+        .create()
+}
+
+pub fn mock_get_contents_directory() -> Mock {
+    mock("GET", "/repos/octokit/octokit.rb/contents/lib/octokit")
+        .with_status(200)
+        .with_body(r#"
+            [
+              {
+                "type": "file",
+                "size": 625,
+                "name": "octokit.rb",
+                "path": "lib/octokit.rb",
+                "sha": "fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                "url": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit.rb",
+                "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                "html_url": "https://github.com/octokit/octokit.rb/blob/master/lib/octokit.rb",
+                "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/lib/octokit.rb",
+                "_links": {
+                  "self": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit.rb",
+                  "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                  "html": "https://github.com/octokit/octokit.rb/blob/master/lib/octokit.rb"
+                }
+              },
+              {
+                "type": "dir",
+                "size": 0,
+                "name": "octokit",
+                "path": "lib/octokit",
+                "sha": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                "url": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit",
+                "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/trees/a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                "html_url": "https://github.com/octokit/octokit.rb/tree/master/lib/octokit",
+                "download_url": null,
+                "_links": {
+                  "self": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit",
+                  "git": "https://api.github.com/repos/octokit/octokit.rb/git/trees/a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                  "html": "https://github.com/octokit/octokit.rb/tree/master/lib/octokit"
+                }
+              }
+            ]
+        "#
+        )
+        .create()
+}
+
+pub fn mock_get_contents_submodule() -> Mock {
+    mock("GET", "/repos/jquery/jquery/contents/test/qunit")
+        .with_status(200)
+        .with_body(r#"
+            {
+              "type": "submodule",
+              "submodule_git_url": "git://github.com/jquery/qunit.git",
+              "size": 0,
+              "name": "qunit",
+              "path": "test/qunit",
+              "sha": "6ca3721222109997540bd6d9ccd396902e0ad2f9",
+              "url": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+              "git_url": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+              "html_url": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+              "download_url": null,
+              "_links": {
+                "git": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+                "self": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+                "html": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9"
+              }
+            }
+        "#
+        )
+        .create()
+}
+
+pub fn mock_get_contents_symlink() -> Mock {
+    mock("GET", "/repos/octokit/octokit.rb/contents/bin/some-symlink")
+        .with_status(200)
+        .with_body(r#"
+            {
+              "type": "symlink",
+              "target": "/path/to/symlink/target",
+              "size": 23,
+              "name": "some-symlink",
+              "path": "bin/some-symlink",
+              "sha": "452a98979c88e093d682cab404a3ec82babebb48",
+              "url": "https://api.github.com/repos/octokit/octokit.rb/contents/bin/some-symlink",
+              "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/452a98979c88e093d682cab404a3ec82babebb48",
+              "html_url": "https://github.com/octokit/octokit.rb/blob/master/bin/some-symlink",
+              "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/bin/some-symlink",
+              "_links": {
+                "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/452a98979c88e093d682cab404a3ec82babebb48",
+                "self": "https://api.github.com/repos/octokit/octokit.rb/contents/bin/some-symlink",
+                "html": "https://github.com/octokit/octokit.rb/blob/master/bin/some-symlink"
+              }
+            }
+        "#
+        )
+        .create()
+}

--- a/integrations/github/src/testing/mod.rs
+++ b/integrations/github/src/testing/mod.rs
@@ -1,4 +1,5 @@
 pub mod check_run;
 pub mod check_suite;
 pub mod client;
+pub mod contents;
 pub mod token;


### PR DESCRIPTION
A new task has been created that fetches a file from GitHub. The implementation does not yet support the full feature set of GitHub's API, and only provides access to files that are smaller than 1MB.