### PR TITLE
Change visibility of GitHub clients to public

### DIFF
--- a/integrations/github/src/client/mod.rs
+++ b/integrations/github/src/client/mod.rs
@@ -1,3 +1,5 @@
+//! Client for GitHub's REST API
+
 use anyhow::{anyhow, Context};
 use reqwest::header::HeaderValue;
 use reqwest::{Client, Method, RequestBuilder};
@@ -10,7 +12,8 @@ use automatons::Error;
 use crate::resource::{AppId, InstallationId};
 use crate::{name, secret};
 
-pub use self::token::{AppScope, InstallationScope, Token, TokenFactory};
+use self::token::TokenFactory;
+pub use self::token::{AppScope, InstallationScope, Token};
 
 mod token;
 
@@ -42,6 +45,7 @@ pub struct GitHubClient {
 
 #[allow(dead_code)] // TODO: Remove when remaining tasks have been migrated from `github-parts`
 impl GitHubClient {
+    /// Initializes a new instance of the GitHub client
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn new(
         github_host: GitHubHost,
@@ -58,6 +62,7 @@ impl GitHubClient {
         }
     }
 
+    /// Send a GET request to GitHub
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub async fn get<T>(&self, endpoint: &str) -> Result<T, Error>
     where
@@ -69,6 +74,7 @@ impl GitHubClient {
         self.send_request(Method::GET, endpoint, body).await
     }
 
+    /// Send a POST request to GitHub
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(body)))]
     pub async fn post<T>(&self, endpoint: &str, body: Option<impl Serialize>) -> Result<T, Error>
     where
@@ -77,6 +83,7 @@ impl GitHubClient {
         self.send_request(Method::POST, endpoint, body).await
     }
 
+    /// Send a PATCH request to GitHub
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(body)))]
     pub async fn patch<T>(&self, endpoint: &str, body: Option<impl Serialize>) -> Result<T, Error>
     where
@@ -130,6 +137,7 @@ impl GitHubClient {
         Ok(data)
     }
 
+    /// Send a paginated request to GitHub
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub async fn paginate<T>(
         &self,

--- a/integrations/github/src/client/token.rs
+++ b/integrations/github/src/client/token.rs
@@ -54,7 +54,7 @@ impl<Scope> Token<Scope> {
 }
 
 #[derive(Clone, Debug)]
-pub struct TokenFactory {
+pub(super) struct TokenFactory {
     github_host: GitHubHost,
     app_id: AppId,
     private_key: PrivateKey,

--- a/integrations/github/src/lib.rs
+++ b/integrations/github/src/lib.rs
@@ -11,11 +11,10 @@
 
 mod macros;
 
+pub mod client;
 pub mod event;
 pub mod resource;
 pub mod task;
-
-mod client;
 
 #[cfg(test)]
 mod testing;


### PR DESCRIPTION
The GitHub client has been exposed to consumers of the crate so that they can initialize it and pass it to tasks.