### PR TITLE
Change visibility of testing module to public

### DIFF
--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.24"
 jsonwebtoken = { version = "8" }
+mockito = "0.31"
 parking_lot = { version = "0.12" }
 reqwest = { version = "0.11", features = ["json"] }
 secrecy = { version = "0.8" }
@@ -41,5 +42,4 @@ base64 = "0.13.0"
 serde_bytes = "0.11.7"
 
 [dev-dependencies]
-mockito = "0.31.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/integrations/github/src/lib.rs
+++ b/integrations/github/src/lib.rs
@@ -16,5 +16,5 @@ pub mod event;
 pub mod resource;
 pub mod task;
 
-#[cfg(test)]
-mod testing;
+#[allow(missing_docs)]
+pub mod testing;


### PR DESCRIPTION
The testing module inside automatons-github has been exposed to consumers of the crate. This makes it easy to reuse the mocks and test custom tasks.

A future change will put this behind a feature flag or something similar to avoid leaking testing dependency into production builds.