### PR TITLE
Rename arguments for tasks

### DIFF
--- a/integrations/github/src/task/create_check_run.rs
+++ b/integrations/github/src/task/create_check_run.rs
@@ -25,7 +25,7 @@ pub struct CreateCheckRun<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
-    check_run_input: &'a CreateCheckRunInput,
+    check_run_args: &'a CreateCheckRunArgs,
 }
 
 /// Input for create check run task
@@ -35,7 +35,7 @@ pub struct CreateCheckRun<'a> {
 ///
 /// https://docs.github.com/en/rest/checks/runs#create-a-check-run
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
-pub struct CreateCheckRunInput {
+pub struct CreateCheckRunArgs {
     /// The name of the check. For example, "code-coverage".
     pub name: CheckRunName,
 
@@ -83,13 +83,13 @@ impl<'a> CreateCheckRun<'a> {
         github_client: &'a GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
-        check_run_input: &'a CreateCheckRunInput,
+        check_run_input: &'a CreateCheckRunArgs,
     ) -> Self {
         Self {
             github_client,
             owner,
             repository,
-            check_run_input,
+            check_run_args: check_run_input,
         }
     }
 
@@ -103,7 +103,7 @@ impl<'a> CreateCheckRun<'a> {
 
         let check_run = self
             .github_client
-            .post(&url, Some(self.check_run_input))
+            .post(&url, Some(self.check_run_args))
             .await
             .context("failed to create check run")?;
 
@@ -118,10 +118,10 @@ mod tests {
     use crate::testing::client::github_client;
     use crate::testing::token::mock_installation_access_tokens;
 
-    use super::{CreateCheckRun, CreateCheckRunInput};
+    use super::{CreateCheckRun, CreateCheckRunArgs};
 
-    fn input() -> CreateCheckRunInput {
-        CreateCheckRunInput {
+    fn input() -> CreateCheckRunArgs {
+        CreateCheckRunArgs {
             name: CheckRunName::new("mighty_readme"),
             head_sha: GitSha::new("ce587453ced02b1526dfb4cb910479d431683101"),
             details_url: None,

--- a/integrations/github/src/task/mod.rs
+++ b/integrations/github/src/task/mod.rs
@@ -2,12 +2,12 @@
 //!
 //! The GitHub integration implements tasks that can be used to create automatons.
 
-pub use self::create_check_run::{CreateCheckRun, CreateCheckRunInput};
+pub use self::create_check_run::{CreateCheckRun, CreateCheckRunArgs};
 pub use self::get_file::GetFile;
 pub use self::list_check_runs_for_check_suite::ListCheckRunsForCheckSuite;
 pub use self::list_check_runs_for_git_sha::ListCheckRunsForGitSha;
 pub use self::list_check_suites::ListCheckSuites;
-pub use self::update_check_run::{UpdateCheckRun, UpdateCheckRunInput};
+pub use self::update_check_run::{UpdateCheckRun, UpdateCheckRunArgs};
 
 mod create_check_run;
 mod get_file;

--- a/integrations/github/src/task/update_check_run.rs
+++ b/integrations/github/src/task/update_check_run.rs
@@ -22,7 +22,7 @@ pub struct UpdateCheckRun<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
-    check_run_input: &'a UpdateCheckRunInput,
+    check_run_args: &'a UpdateCheckRunArgs,
 }
 
 /// Input for update check run task
@@ -32,7 +32,7 @@ pub struct UpdateCheckRun<'a> {
 ///
 /// https://docs.github.com/en/rest/checks/runs#update-a-check-run
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
-pub struct UpdateCheckRunInput {
+pub struct UpdateCheckRunArgs {
     /// The unique identifier of the check run.
     pub check_run_id: CheckRunId,
 
@@ -80,13 +80,13 @@ impl<'a> UpdateCheckRun<'a> {
         github_client: &'a GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
-        check_run_input: &'a UpdateCheckRunInput,
+        check_run_input: &'a UpdateCheckRunArgs,
     ) -> Self {
         Self {
             github_client,
             owner,
             repository,
-            check_run_input,
+            check_run_args: check_run_input,
         }
     }
 
@@ -98,12 +98,12 @@ impl<'a> UpdateCheckRun<'a> {
             "/repos/{}/{}/check-runs/{}",
             self.owner.get(),
             self.repository.get(),
-            self.check_run_input.check_run_id
+            self.check_run_args.check_run_id
         );
 
         let check_run = self
             .github_client
-            .patch(&url, Some(self.check_run_input))
+            .patch(&url, Some(self.check_run_args))
             .await
             .context("failed to update check run")?;
 
@@ -118,10 +118,10 @@ mod tests {
     use crate::testing::client::github_client;
     use crate::testing::token::mock_installation_access_tokens;
 
-    use super::{UpdateCheckRun, UpdateCheckRunInput};
+    use super::{UpdateCheckRun, UpdateCheckRunArgs};
 
-    fn input() -> UpdateCheckRunInput {
-        UpdateCheckRunInput {
+    fn input() -> UpdateCheckRunArgs {
+        UpdateCheckRunArgs {
             check_run_id: CheckRunId::new(4),
             name: Some(CheckRunName::new("mighty_readme")),
             details_url: None,


### PR DESCRIPTION
The arguments for tasks have been renamed, and now use the prefix `Args` instead of `Input`. This is more expressive, and avoids weird looking names when something is called an `Output` (`OutputArgs` instead of `OutputInput`).