### PR TITLE
Replace all usages of outputs with args

### DIFF
--- a/integrations/github/src/task/create_check_run.rs
+++ b/integrations/github/src/task/create_check_run.rs
@@ -7,9 +7,9 @@ use automatons::Error;
 
 use crate::client::GitHubClient;
 use crate::resource::{
-    CheckRun, CheckRunConclusion, CheckRunName, CheckRunOutput, CheckRunStatus, GitSha, Login,
-    RepositoryName,
+    CheckRun, CheckRunConclusion, CheckRunName, CheckRunStatus, GitSha, Login, RepositoryName,
 };
+use crate::task::CheckRunOutputArgs;
 
 /// Create a check run
 ///
@@ -74,7 +74,7 @@ pub struct CreateCheckRunArgs {
     /// Check runs can accept a variety of data in the output object, including a title and summary
     /// and can optionally provide descriptive details about the run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub output: Option<CheckRunOutput>,
+    pub output: Option<CheckRunOutputArgs>,
 }
 
 impl<'a> CreateCheckRun<'a> {

--- a/integrations/github/src/task/mod.rs
+++ b/integrations/github/src/task/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! The GitHub integration implements tasks that can be used to create automatons.
 
+use serde::Serialize;
+
+use crate::resource::{CheckRunOutputSummary, CheckRunOutputTitle};
+
 pub use self::create_check_run::{CreateCheckRun, CreateCheckRunArgs};
 pub use self::get_file::GetFile;
 pub use self::list_check_runs_for_check_suite::ListCheckRunsForCheckSuite;
@@ -15,3 +19,22 @@ mod list_check_runs_for_check_suite;
 mod list_check_runs_for_git_sha;
 mod list_check_suites;
 mod update_check_run;
+
+/// Input for check run output
+///
+/// Check runs can accept a variety of data in the `output` object, including a `title` and
+/// `summary` and can optionally provide descriptive details about the run.
+///
+/// https://docs.github.com/en/rest/checks/runs#update-a-check-run
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+pub struct CheckRunOutputArgs {
+    /// The title of the check run output.
+    pub title: CheckRunOutputTitle,
+
+    /// The summary of the check run output.
+    pub summary: CheckRunOutputSummary,
+
+    /// The text with descriptive details about the check run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}

--- a/integrations/github/src/task/update_check_run.rs
+++ b/integrations/github/src/task/update_check_run.rs
@@ -7,9 +7,9 @@ use automatons::Error;
 
 use crate::client::GitHubClient;
 use crate::resource::{
-    CheckRun, CheckRunConclusion, CheckRunId, CheckRunName, CheckRunOutputSummary,
-    CheckRunOutputTitle, CheckRunStatus, Login, RepositoryName,
+    CheckRun, CheckRunConclusion, CheckRunId, CheckRunName, CheckRunStatus, Login, RepositoryName,
 };
+use crate::task::CheckRunOutputArgs;
 
 /// Update a check run
 ///
@@ -72,25 +72,6 @@ pub struct UpdateCheckRunArgs {
     /// and can optionally provide descriptive details about the run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<CheckRunOutputArgs>,
-}
-
-/// Input for check run output
-///
-/// Check runs can accept a variety of data in the `output` object, including a `title` and
-/// `summary` and can optionally provide descriptive details about the run.
-///
-/// https://docs.github.com/en/rest/checks/runs#update-a-check-run
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
-pub struct CheckRunOutputArgs {
-    /// The title of the check run output.
-    pub title: CheckRunOutputTitle,
-
-    /// The summary of the check run output.
-    pub summary: CheckRunOutputSummary,
-
-    /// The text with descriptive details about the check run.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
 }
 
 impl<'a> UpdateCheckRun<'a> {


### PR DESCRIPTION
The two tasks that create and update check runs respectively have been refactored to use the new args type exclusively and consistently.