### PR TITLE
Bump crates from 0.2.0 to 0.3.0

### DIFF
--- a/automatons/Cargo.toml
+++ b/automatons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automatons"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 description = "Automation framework for software developers"

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automatons-github"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 description = "GitHub integration for the automatons framework"
@@ -20,7 +20,7 @@ keywords = [
 
 [dependencies.automatons]
 path = "../../automatons"
-version = "0.2"
+version = "0.3"
 features = ["reqwest"]
 
 [dependencies]


### PR DESCRIPTION
We have tried to refactor our GitHub App `checkbot` to the current API of this crate, and have run into some serious troubles. Most importantly, it is very difficult to work with the resources in this crate. While they are good representations of GitHub's API, they are almost impossible to test. We could try to create a good API for building test doubles, but initial experiments were very time-consuming and brittle.

We are cutting a release once again to mark the end of this design iteration, and prepare for a rewrite in the next commit.