### PR TITLE
Add convertion for sqlx errors

### DIFF
--- a/automatons/Cargo.toml
+++ b/automatons/Cargo.toml
@@ -22,6 +22,7 @@ keywords = [
 anyhow = "1"
 async-trait = "0.1"
 reqwest = { version = "0.11", optional = true }
+sqlx = { version = "0.6", features = ["runtime-tokio-native-tls"], optional = true }
 thiserror = "1"
 tracing = { version = "0.1", optional = true }
 

--- a/automatons/src/error.rs
+++ b/automatons/src/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
     #[error("{0}")]
     Configuration(String),
 
+    #[cfg(feature = "sqlx")]
+    #[error("{0}")]
+    Database(#[from] sqlx::Error),
+
     #[error("failed to find resource at {0}")]
     NotFound(String),
 


### PR DESCRIPTION
A new feature has been added to the crate that allows `sqlx::Error` to be converted to an `automatons::Error`.